### PR TITLE
chore: update references to new repo name

### DIFF
--- a/.devcontainer/post_install.sh
+++ b/.devcontainer/post_install.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Install package
-sudo su - vscode bash -c "cd /workspaces/unleash-client-python; pip install -U -r requirements.txt; python -m build; ./scripts/get-spec.sh;"
+sudo su - vscode bash -c "cd /workspaces/unleash-python-sdk; pip install -U -r requirements.txt; python -m build; ./scripts/get-spec.sh;"
 
 # Install pre-config
 pip install pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to unleash-client-python
+# Contributing to unleash-python-sdk
 We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 
 - Reporting a bug

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unleash Client SDK for Python
+# Unleash SDK for Python
 
 ![](https://github.com/unleash/unleash-python-sdk/workflows/CI/badge.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-python-sdk/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-python-sdk?branch=main) [![PyPI version](https://badge.fury.io/py/UnleashClient.svg)](https://badge.fury.io/py/UnleashClient) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/UnleashClient.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unleash Client SDK for Python
 
-![](https://github.com/unleash/unleash-client-python/workflows/CI/badge.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-client-python/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-client-python?branch=main) [![PyPI version](https://badge.fury.io/py/UnleashClient.svg)](https://badge.fury.io/py/UnleashClient) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/UnleashClient.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![](https://github.com/unleash/unleash-python-sdk/workflows/CI/badge.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-python-sdk/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-python-sdk?branch=main) [![PyPI version](https://badge.fury.io/py/UnleashClient.svg)](https://badge.fury.io/py/UnleashClient) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/UnleashClient.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Unleash is a private, secure, and scalable [feature management platform](https://www.getunleash.io/) built to reduce the risk of releasing new features and accelerate software development. This server-side Python SDK is designed to help you integrate with Unleash and evaluate feature flags inside your application.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import UnleashClient  # noqa: F401
 
 # -- Project information -----------------------------------------------------
 
-project = "unleash-client-python"
+project = "unleash-python-sdk"
 copyright = "2022 Unleash"
 author = "Ivan Lee"
 version = version("UnleashClient")
@@ -65,6 +65,6 @@ html_static_path = ["_static"]
 html_context = {
     "display_github": True,
     "github_user": "unleash",
-    "github_repo": "unleash-client-python",
+    "github_repo": "unleash-python-sdk",
     "github_version": "main/docs/",
 }

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -115,7 +115,7 @@ Using ``UnleashClient`` with Gitlab
 
 `Gitlab's feature flags <https://docs.gitlab.com/ee/user/project/operations/feature_flags.html>`_ only supports the features URL.  (API calls to the registration URL and metrics URL will fail with HTTP Error code 401.)
 
-If using `unleash-client-python` with Gitlab's feature flags, we recommend initializing the client with `disable_metrics` = True and `disable_registration` = True.
+If using `unleash-python-sdk` with Gitlab's feature flags, we recommend initializing the client with `disable_metrics` = True and `disable_registration` = True.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ dependencies=[
 ]
 
 [project.urls]
-Homepage = "https://github.com/Unleash/unleash-client-python"
-Documentation = "https://docs.getunleash.io/unleash-client-python"
-Changelog = "https://github.com/Unleash/unleash-client-python/blob/main/CHANGELOG.md"
-Repository = "https://github.com/Unleash/unleash-client-python"
-Issues = "https://github.com/Unleash/unleash-client-python/issues"
+Homepage = "https://github.com/Unleash/unleash-python-sdk"
+Documentation = "https://docs.getunleash.io/unleash-python-sdk"
+Changelog = "https://github.com/Unleash/unleash-python-sdk/blob/main/CHANGELOG.md"
+Repository = "https://github.com/Unleash/unleash-python-sdk"
+Issues = "https://github.com/Unleash/unleash-python-sdk/issues"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
# Description

The repository was renamed from unleash-client-python to unleash-python-sdk. This PR updates all references to the repository (except for CHANGELOG.md).

Because the artifact remains unchanged, that's all we need to update.

## Type of change
- Documentation: code remains unchanged

# Checklist:

N/A
