### PR TITLE
fix: send client spec version when fetching features

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -23,6 +23,7 @@ from UnleashClient.connectors import (
     StreamingConnector,
 )
 from UnleashClient.constants import (
+    APPLICATION_HEADERS,
     DISABLED_VARIATION,
     ETAG,
     METRIC_LAST_SENT_TIME,
@@ -290,6 +291,7 @@ class UnleashClient:
                 start_scheduler = False
                 base_headers = {
                     **self.unleash_custom_headers,
+                    **APPLICATION_HEADERS,
                     "unleash-connection-id": self.connection_id,
                     "unleash-appname": self.unleash_app_name,
                     "unleash-instanceid": self.unleash_instance_id,

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1,4 +1,5 @@
 import json
+import re
 import threading
 import time
 import uuid
@@ -1487,3 +1488,21 @@ def test_uc_bootstrap_initializes_offline_connector():
     assert unleash_client.is_enabled("testFlag")
 
     unleash_client.destroy()
+
+@responses.activate
+def test_spec_header_is_sent_when_fetching_features():
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+
+    unleash_client = UnleashClient(
+        URL, APP_NAME, disable_metrics=True, disable_registration=True
+    )
+    unleash_client.initialize_client()
+    client_spec = responses.calls[0].request.headers[
+        "Unleash-Client-Spec"
+    ]
+
+    ## assert that the client spec looks like a semver string
+    semver_regex = r"^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+    assert re.match(semver_regex, client_spec)

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1489,6 +1489,7 @@ def test_uc_bootstrap_initializes_offline_connector():
 
     unleash_client.destroy()
 
+
 @responses.activate
 def test_spec_header_is_sent_when_fetching_features():
     responses.add(
@@ -1499,9 +1500,7 @@ def test_spec_header_is_sent_when_fetching_features():
         URL, APP_NAME, disable_metrics=True, disable_registration=True
     )
     unleash_client.initialize_client()
-    client_spec = responses.calls[0].request.headers[
-        "Unleash-Client-Spec"
-    ]
+    client_spec = responses.calls[0].request.headers["Unleash-Client-Spec"]
 
     ## assert that the client spec looks like a semver string
     semver_regex = r"^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"


### PR DESCRIPTION
Send the client spec version when fetching features. This is important because it allows the Unleash server to know that it can send segments as standalone entities. This means better compression on the sending of features - better for the client and better for the server