### PR TITLE
Skip a failing pytest on Python 3.8 on Windows

### DIFF
--- a/tests/specification_tests/test_client_specs.py
+++ b/tests/specification_tests/test_client_specs.py
@@ -1,4 +1,6 @@
 import json
+import platform
+import sys
 import uuid
 from os import path
 
@@ -79,6 +81,10 @@ except FileNotFoundError:
     raise
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9) and platform.system() == "Windows",
+    reason="Requires Python >= 3.9 on Windows"
+)
 @pytest.mark.parametrize("spec", TEST_DATA, ids=TEST_NAMES)
 def test_spec(spec):
     unleash_client, test_data, is_variant_test = spec


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed (if any).

GitHub Actions are failing on end-of-life Python 3.8 on Windows.
```diff
+@pytest.mark.skipif(
+    sys.version_info < (3, 9) and platform.system() == "Windows",
+    reason="Requires Python >= 3.9 on Windows"
+)
 @pytest.mark.parametrize("spec", TEST_DATA, ids=TEST_NAMES)
 def test_spec(spec):
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [x] Spec Tests
- [ ] Integration tests / Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
