### PR TITLE
chore: remove the global thread tear down in the streaming tests

### DIFF
--- a/tests/unit_tests/test_client_streaming.py
+++ b/tests/unit_tests/test_client_streaming.py
@@ -14,27 +14,11 @@ from UnleashClient import INSTANCES, UnleashClient
 from UnleashClient.cache import FileCache
 
 
-def cleanup_threads():
-    """Wait for all background threads to finish."""
-    for thread in threading.enumerate():
-        if thread != threading.current_thread() and thread.is_alive():
-            if (
-                hasattr(thread, "_stop")
-                or "unleash" in thread.name.lower()
-                or "scheduler" in thread.name.lower()
-            ):
-                try:
-                    thread.join(timeout=2.0)
-                except Exception:
-                    pass
-
-
 @pytest.fixture(autouse=True)
 def reset_instances(tmp_path):
     """Reset instances before each test and ensure clean cache."""
     INSTANCES._reset()
     yield
-    cleanup_threads()
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_client_streaming.py
+++ b/tests/unit_tests/test_client_streaming.py
@@ -3,7 +3,6 @@ Unit tests for streaming connector using urllib3 mocking for low-level HTTP inte
 """
 
 import json
-import threading
 import time
 from io import BytesIO
 


### PR DESCRIPTION
The streaming tests currently attempt to tear down all running threads. Which is a pity because a bunch of tests in the SDK leave their background threads alive, expecting process exit to terminate those. They also don't respect the streaming tests' attempt to tear them down so they wait until the test harness times out. 

This means that running the whole test suite takes 10 minutes

This just throws that tear down away. There's no reason for it - looks like runaway ChatGPT