### PR TITLE
Create new EventDispatcher to move user-provided callback execution out of the main thread

### DIFF
--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -149,7 +149,7 @@ class EventDispatcher:
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
         close() signals the dispatcher to stop. It enqueues a Shutdown sentinel to the queue, and waits
-        for its signal to be set. The worker thread will eventually get to the sentinal, set its ``done``
+        for its signal to be set. The worker thread will eventually get to the sentinel, set its ``done``
         signal, which will wake this thread and allow it to join the worker thread.
 
         Even if the Shutdown sentinel cannot be enqueued, the worker thread will still be stopped and the dispatcher marked as closed.

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -1,3 +1,6 @@
+from threading import Event
+
+
 import queue
 import threading
 import time
@@ -72,19 +75,18 @@ class _Shutdown:
     Sentinel that tells the worker to stop draining and exit.
     """
 
-    __slots__ = ()
+    def __init__(self):
+        self.done: Event = threading.Event()
 
     def __repr__(self) -> str:
         return "<_SHUTDOWN>"
-
-
-_SHUTDOWN = _Shutdown()
 
 
 _QueueItem = Union[BaseEvent, _Shutdown]
 
 DEFAULT_MAX_QUEUE_SIZE = 100
 DEFAULT_TIMEOUT = 2.0
+DEFAULT_PUT_TIMEOUT = 0.1
 
 
 class EventDispatcher:
@@ -125,7 +127,9 @@ class EventDispatcher:
         with self._lock:
             return self._dropped
 
-    def emit_event(self, event: BaseEvent) -> None:
+    def emit_event(
+        self, event: BaseEvent, timeout: float = DEFAULT_PUT_TIMEOUT
+    ) -> None:
         """
         Queues an event for delivery.  Never blocks the caller.  READY events after
         the first one are ignored.
@@ -138,27 +142,12 @@ class EventDispatcher:
             if self._closed:
                 return
 
-            if event.event_type is UnleashEventType.READY:
-                if self._ready_fired:
-                    return
-                self._ready_fired = True
-
-            self._start_worker()
-
             try:
-                self._queue.put_nowait(event)
-                return
+                self._start_worker()
+                self._enqueue_event(event, timeout=timeout)
             except queue.Full:
-                self._dropped += 1
-                should_warn = not self._warned_about_full_queue
-                self._warned_about_full_queue = True
-
-        if should_warn:
-            LOGGER.warning(
-                "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
-            )
-        else:
-            LOGGER.debug("Event was dropped because queue is full.")
+                self._count_dropped_event()
+                self._maybe_warn_about_full_queue()
 
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
@@ -169,19 +158,34 @@ class EventDispatcher:
             if self._closed:
                 return
             self._closed = True
-            thread = self._thread
 
-        if thread is None:
+            start_time = time.monotonic()
+            try:
+                shutdown_signal = self._signal_shutdown(
+                    timeout=_remaining(start_time, timeout)
+                )
+                _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
+            except queue.Full:
+                pass
+            finally:
+                self._stop_worker(timeout=_remaining(start_time, timeout))
+
+    def _signal_shutdown(self, timeout: float) -> _Shutdown:
+        """Signals the worker to stop draining and exit.  Caller must hold ``self._lock``."""
+        signal = _Shutdown()
+        self._enqueue_event(signal, timeout=timeout)
+        return signal
+
+    def _stop_worker(self, timeout: float) -> None:
+        """Stops the worker thread.  Caller must hold ``self._lock``."""
+        if self._thread is None:
             return
 
-        deadline = time.monotonic() + timeout
-        try:
-            self._queue.put(_SHUTDOWN, timeout=timeout)
-        except queue.Full:
-            LOGGER.debug("Timed out signalling shutdown to the event dispatcher.")
+        if not self._thread.is_alive():
+            self._thread = None
             return
 
-        thread.join(max(0.0, deadline - time.monotonic()))
+        return self._thread.join(timeout=timeout)
 
     def _start_worker(self) -> None:
         """Starts a worker if one is not running.  Caller must hold ``self._lock``."""
@@ -193,6 +197,28 @@ class EventDispatcher:
         )
         self._thread.start()
 
+    def _enqueue_event(
+        self, event: Union[BaseEvent, _Shutdown], timeout: float
+    ) -> None:
+        if (
+            isinstance(event, UnleashEvent)
+            and event.event_type is UnleashEventType.READY
+        ):
+            if self._ready_fired:
+                return
+            self._ready_fired = True
+
+        self._queue.put(item=event, timeout=timeout)
+
+    def _count_dropped_event(self) -> None:
+        self._dropped += 1
+
+    def _maybe_warn_about_full_queue(self) -> None:
+        if not self._warned_about_full_queue:
+            LOGGER.warning(
+                "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
+            )
+
     def _run(self) -> None:
         """_run is the inifinite loop that drains the queue of events.
 
@@ -201,9 +227,15 @@ class EventDispatcher:
             item = self._queue.get()
 
             if isinstance(item, _Shutdown):
+                item.done.set()
                 return
 
             try:
                 self._callback(item)
             except Exception as exc:
                 LOGGER.warning("Error in event callback: %s", exc)
+
+
+def _remaining(start_time: float, timeout: float) -> float:
+    """Returns the remaining time until the timeout expires."""
+    return max(0.0, timeout - (time.monotonic() - start_time))

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -222,15 +222,17 @@ class EventDispatcher:
         The caller will wait for at most ``timeout`` seconds to enqueue the event.
         Caller must hold ``self._lock``.
         """
-        if (
-            isinstance(event, UnleashEvent)
-            and event.event_type is UnleashEventType.READY
-        ):
-            if self._ready_fired:
-                return
-            self._ready_fired = True
+        is_ready_event = (
+            isinstance(event, BaseEvent) and event.event_type is UnleashEventType.READY
+        )
+
+        if is_ready_event and self._ready_fired:
+            return
 
         self._queue.put(item=event, timeout=timeout)
+
+        if is_ready_event:
+            self._ready_fired = True
 
     def _count_dropped_event(self) -> None:
         self._dropped += 1

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -149,7 +149,7 @@ class EventDispatcher:
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
         close() signals the dispatcher to stop. It enqueues a Shutdown sentinel to the queue, and waits
-        for its signal to be set. The worker thread will eventually get to the sentinel, set its ``done``
+        for its signal to be set. The worker thread will eventually get to the sentinel, set its ``done``
         signal, which will wake this thread and allow it to join the worker thread.
 
         Even if the Shutdown sentinel cannot be enqueued, the worker thread will still be stopped and the dispatcher marked as closed.

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -94,7 +94,7 @@ class _FlushMarker:
 
 _QueueItem = Union[BaseEvent, _Shutdown, _FlushMarker]
 
-DEFAULT_MAX_QUEUE_SIZE = 10_000
+DEFAULT_MAX_QUEUE_SIZE = 100
 DEFAULT_TIMEOUT = 2.0
 
 

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -81,18 +81,7 @@ class _Shutdown:
 _SHUTDOWN = _Shutdown()
 
 
-class _FlushMarker:
-    """
-    Sentinel that lets a caller wait until everything queued ahead of it has been delivered.
-    """
-
-    __slots__ = ("done",)
-
-    def __init__(self) -> None:
-        self.done = threading.Event()
-
-
-_QueueItem = Union[BaseEvent, _Shutdown, _FlushMarker]
+_QueueItem = Union[BaseEvent, _Shutdown]
 
 DEFAULT_MAX_QUEUE_SIZE = 100
 DEFAULT_TIMEOUT = 2.0
@@ -171,25 +160,6 @@ class EventDispatcher:
         else:
             LOGGER.debug("Event was dropped because queue is full.")
 
-    def flush(self, timeout: float = DEFAULT_TIMEOUT) -> bool:
-        """
-        Blocks until every event queued so far has been handed to the callback.
-
-        :return: True if the queue drained in time, False otherwise.
-        """
-        thread = self._thread
-        if thread is None or not thread.is_alive():
-            return True
-
-        deadline = time.monotonic() + timeout
-        marker = _FlushMarker()
-        try:
-            self._queue.put(marker, timeout=timeout)
-        except queue.Full:
-            return False
-
-        return marker.done.wait(max(0.0, deadline - time.monotonic()))
-
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
         Stops the dispatcher.  Events already queued are delivered first, but only
@@ -230,30 +200,10 @@ class EventDispatcher:
         while True:
             item = self._queue.get()
 
-            if isinstance(item, _FlushMarker):
-                item.done.set()
-                continue
-
             if isinstance(item, _Shutdown):
-                self._release_flush_markers()
                 return
 
             try:
                 self._callback(item)
             except Exception as exc:
                 LOGGER.warning("Error in event callback: %s", exc)
-
-    def _release_flush_markers(self) -> None:
-        """
-        Wakes anything that raced close() and landed behind the shutdown sentinel,
-        rather than leaving it blocked for its full timeout.  Events found back there
-        are discarded: close() only promises to deliver what was queued before it.
-        """
-        while True:
-            try:
-                item = self._queue.get_nowait()
-            except queue.Empty:
-                return
-
-            if isinstance(item, _FlushMarker):
-                item.done.set()

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -1,8 +1,13 @@
+import queue
+import threading
+import time
 from dataclasses import dataclass
 from enum import Enum
 from json import loads
-from typing import Optional
+from typing import Any, Callable, Optional
 from uuid import UUID
+
+from UnleashClient.utils import LOGGER
 
 
 class UnleashEventType(Enum):
@@ -60,3 +65,178 @@ class UnleashFetchedEvent(BaseEvent):
         if not hasattr(self, "_parsed_payload"):
             self._parsed_payload = loads(self.raw_features)["features"]
         return self._parsed_payload
+
+
+DEFAULT_MAX_QUEUE_SIZE = 10_000
+DEFAULT_TIMEOUT = 2.0
+
+_SHUTDOWN = object()
+
+
+class _FlushMarker:
+    """
+    Sentinel that lets a caller wait until everything queued ahead of it has been delivered.
+    """
+
+    __slots__ = ("done",)
+
+    def __init__(self) -> None:
+        self.done = threading.Event()
+
+
+@dataclass
+class EventDispatcherOptions:
+    """
+    Configuration for the event dispatcher.  Intentionally empty for now.
+    """
+
+
+class EventDispatcher:
+    """
+    Delivers events to a user supplied callback on a dedicated background thread.
+
+    ``emit_event`` only ever enqueues, so whoever emits an event is never blocked by
+    a slow callback, and callback exceptions stay contained to the worker thread.
+    Events are dropped, and counted, when the queue is saturated.
+
+    Every event, READY included, is handed to the same callback.  READY is only ever
+    delivered once, no matter how many connectors emit it or from which thread.
+
+    :param callback: Function to hand events to.
+    :param options: Optional configuration object.
+    :param max_size: Maximum number of events to hold before dropping.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[BaseEvent], None],
+        options: Optional[EventDispatcherOptions] = None,
+        max_size: int = DEFAULT_MAX_QUEUE_SIZE,
+    ) -> None:
+        self._callback = callback
+        self._options = options or EventDispatcherOptions()
+        self._queue: queue.Queue = queue.Queue(maxsize=max_size)
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._dropped = 0
+        self._warned_about_full_queue = False
+        self._ready_fired = False
+        self._closed = False
+
+    @property
+    def dropped_events(self) -> int:
+        """
+        Number of events that were never handed to the callback because the queue
+        was full.
+        """
+        with self._lock:
+            return self._dropped
+
+    def emit_event(self, event: BaseEvent) -> None:
+        """
+        Queues an event for delivery.  Never blocks the caller.  READY events after
+        the first one are ignored.
+        """
+        with self._lock:
+            if self._closed:
+                return
+
+            if event.event_type is UnleashEventType.READY:
+                if self._ready_fired:
+                    return
+                self._ready_fired = True
+
+        self._enqueue(event)
+
+    def flush(self, timeout: float = DEFAULT_TIMEOUT) -> bool:
+        """
+        Blocks until every event queued so far has been handed to the callback.
+
+        :return: True if the queue drained in time, False otherwise.
+        """
+        thread = self._thread
+        if thread is None or not thread.is_alive():
+            return True
+
+        deadline = time.monotonic() + timeout
+        marker = _FlushMarker()
+        try:
+            self._queue.put(marker, timeout=timeout)
+        except queue.Full:
+            return False
+
+        return marker.done.wait(max(0.0, deadline - time.monotonic()))
+
+    def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
+        """
+        Stops the dispatcher.  Events already queued are delivered first, but only
+        for as long as the timeout allows.  Calling this more than once is a no-op.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            thread = self._thread
+
+        if thread is None:
+            return
+
+        deadline = time.monotonic() + timeout
+        try:
+            self._queue.put(_SHUTDOWN, timeout=timeout)
+        except queue.Full:
+            LOGGER.debug("Timed out signalling shutdown to the event dispatcher.")
+            return
+
+        thread.join(max(0.0, deadline - time.monotonic()))
+
+    def _enqueue(self, item: Any) -> None:
+        self._ensure_worker()
+
+        try:
+            self._queue.put_nowait(item)
+        except queue.Full:
+            with self._lock:
+                self._dropped += 1
+                should_warn = not self._warned_about_full_queue
+                self._warned_about_full_queue = True
+
+            if should_warn:
+                LOGGER.warning(
+                    "Unleash event queue is full, events are being dropped. "
+                    "This usually means the event callback is too slow."
+                )
+            else:
+                LOGGER.debug("Event was dropped because queue is full.")
+
+    def _ensure_worker(self) -> None:
+        """Initializes a worker if one is not started. Further calls to _ensure_worker are no-ops."""
+        if self._thread is not None:
+            return
+
+        with self._lock:
+            if self._thread is not None or self._closed:
+                return
+            self._thread = threading.Thread(
+                target=self._run, name="UnleashEventDispatcher", daemon=True
+            )
+            self._thread.start()
+
+    def _run(self) -> None:
+        """_run is the inifinite loop that drains the queue of events.
+
+        It blocks until an element is available."""
+        while True:
+            item = self._queue.get()
+
+            if item is _SHUTDOWN:
+                return
+
+            if isinstance(item, _FlushMarker):
+                item.done.set()
+                continue
+
+            try:
+                self._callback(item)
+            except Exception as exc:
+                LOGGER.warning("Error in event callback: %s", exc)

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -1,10 +1,8 @@
 import queue
 import threading
-import time
 from dataclasses import dataclass
 from enum import Enum
 from json import loads
-from threading import Event
 from typing import Callable, Optional, Union
 from uuid import UUID
 
@@ -68,199 +66,108 @@ class UnleashFetchedEvent(BaseEvent):
         return self._parsed_payload
 
 
-class _Shutdown:
-    """
-    Sentinel that tells the worker to stop draining and exit.
-    """
-
-    def __init__(self):
-        self.done: Event = threading.Event()
-
-    def __repr__(self) -> str:
-        return "<_SHUTDOWN>"
-
-
-_QueueItem = Union[BaseEvent, _Shutdown]
-
 DEFAULT_MAX_QUEUE_SIZE = 100
 DEFAULT_TIMEOUT = 2.0
-DEFAULT_PUT_TIMEOUT = 0.1
+
+
+class _ShutdownMarker:
+    pass
+
+
+_SHUTDOWN_WAKER: _ShutdownMarker = _ShutdownMarker()
 
 
 class EventDispatcher:
-    """
-    Delivers events to a user supplied callback on a dedicated background thread.
-
-    ``emit_event`` only ever enqueues, so whoever emits an event is never blocked by
-    a slow callback, and callback exceptions stay contained to the worker thread.
-    Events are dropped, and counted, when the queue is saturated.
-
-    Every event, READY included, is handed to the same callback.  READY is only ever
-    delivered once, no matter how many connectors emit it or from which thread.
-
-    :param callback: Function to hand events to.
-    :param max_size: Maximum number of events to hold before dropping.
-    """
-
     def __init__(
         self,
         callback: Callable[[BaseEvent], None],
         max_size: int = DEFAULT_MAX_QUEUE_SIZE,
     ) -> None:
-        self._callback = callback
-        self._queue: queue.Queue[_QueueItem] = queue.Queue(maxsize=max_size)
+        self._callback: Callable[[BaseEvent], None] = callback
+        self._queue: queue.Queue[Union[_ShutdownMarker, BaseEvent]] = queue.Queue(
+            maxsize=max_size
+        )
         self._lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
+        self._closed = threading.Event()
         self._dropped = 0
-        self._warned_about_full_queue = False
-        self._ready_fired = False
-        self._closed = False
+        self._ready_delivered = False
+
+    def emit_event(self, event: BaseEvent) -> None:
+        with self._lock:
+            if self._closed.is_set():
+                return
+
+            self._start_worker()
+
+            is_ready_event = event.event_type == UnleashEventType.READY
+
+            if is_ready_event and self._ready_delivered:
+                return
+
+            try:
+                self._queue.put_nowait(event)
+                if is_ready_event:
+                    self._ready_delivered = True
+            except queue.Full:
+                self._dropped += 1
+                should_warn = self._dropped == 1
+            else:
+                return
+
+        if should_warn:
+            LOGGER.warning("Unleash event queue is full; events are being dropped.")
 
     @property
     def dropped_events(self) -> int:
-        """
-        Number of events that were never handed to the callback because the queue
-        was full.
-        """
         with self._lock:
             return self._dropped
 
-    def emit_event(
-        self, event: BaseEvent, timeout: float = DEFAULT_PUT_TIMEOUT
-    ) -> None:
-        """
-        Enqueues an event to be delivered to the callback.  If the queue is full, the
-        event is dropped and counted.  If the dispatcher has been closed, the event is
-        ignored.  This method is thread safe.
-
-        The caller will wait for at most ``DEFAULT_PUT_TIMEOUT`` seconds to enqueue the event.
-        """
-        with self._lock:
-            if self._closed:
-                return
-
-            try:
-                self._start_worker()
-                self._enqueue_event(event, timeout=timeout)
-            except queue.Full:
-                self._count_dropped_event()
-                self._maybe_warn_about_full_queue()
-
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
-        thread: Optional[threading.Thread]
-        start_time = time.monotonic()
         with self._lock:
-            if self._closed:
+            if self._closed.is_set():
                 return
 
-            self._closed = True
+            self._closed.set()
             thread = self._thread
 
-        if thread is None:
-            return
-
-        if threading.current_thread() is thread:
-            try:
-                self._queue.put(item=_Shutdown(), timeout=0)
+            if thread is None:
                 return
+
+            try:
+                self._queue.put_nowait(_SHUTDOWN_WAKER)
             except queue.Full:
-                # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as ``_closed``.
-                # Not much we can do about it, but at least we won't leave the thread running.
                 pass
 
-        shutdown_signal: Optional[_Shutdown] = None
-        try:
-            try:
-                shutdown_signal = self._signal_shutdown(
-                    timeout=_remaining(start_time, timeout)
-                )
-            except queue.Full:
-                shutdown_signal = None
-
-            if shutdown_signal is not None:
-                _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
-        finally:
-            thread.join(timeout=_remaining(start_time, timeout))
-            with self._lock:
-                if self._thread is thread and not thread.is_alive():
-                    self._thread = None
-
-    def _signal_shutdown(self, timeout: float) -> _Shutdown:
-        """Signals the worker to stop draining and exit.  Caller must hold ``self._lock``."""
-        signal = _Shutdown()
-        self._enqueue_event(signal, timeout=timeout)
-        return signal
-
-    def _stop_worker(self, timeout: float) -> None:
-        """Stops the worker thread.  Caller must hold ``self._lock``."""
-        if self._thread is None:
-            return
-
-        if not self._thread.is_alive():
-            self._thread = None
-            return
-
-        return self._thread.join(timeout=timeout)
+        if threading.current_thread() is not thread:
+            thread.join(timeout)
 
     def _start_worker(self) -> None:
-        """Starts a worker if one is not running.  Caller must hold ``self._lock``."""
         if self._thread is not None:
             return
 
         self._thread = threading.Thread(
-            target=self._run, name="UnleashEventDispatcher", daemon=True
+            target=self._run,
+            name="UnleashEventDispatcher",
+            daemon=True,
         )
         self._thread.start()
 
-    def _enqueue_event(
-        self, event: Union[BaseEvent, _Shutdown], timeout: float
-    ) -> None:
-        """Enqueues an event to be delivered to the callback.  If the queue is full, the
-        event is dropped and counted.  If the dispatcher has been closed, the event is
-        ignored.
-
-        The caller will wait for at most ``timeout`` seconds to enqueue the event.
-        Caller must hold ``self._lock``.
-        """
-        is_ready_event = (
-            isinstance(event, BaseEvent) and event.event_type is UnleashEventType.READY
-        )
-
-        if is_ready_event and self._ready_fired:
-            return
-
-        self._queue.put(item=event, timeout=timeout)
-
-        if is_ready_event:
-            self._ready_fired = True
-
-    def _count_dropped_event(self) -> None:
-        self._dropped += 1
-
-    def _maybe_warn_about_full_queue(self) -> None:
-        if not self._warned_about_full_queue:
-            LOGGER.warning(
-                "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
-            )
-            self._warned_about_full_queue = True
-
     def _run(self) -> None:
-        """_run is the inifinite loop that drains the queue of events.
+        try:
+            while True:
+                item: Union[_ShutdownMarker, BaseEvent] = self._queue.get()
 
-        It blocks until an element is available."""
-        while True:
-            item: _QueueItem = self._queue.get()
+                if isinstance(item, _ShutdownMarker):
+                    return
 
-            if isinstance(item, _Shutdown):
-                item.done.set()
-                return
+                try:
+                    self._callback(item)
+                except Exception:
+                    LOGGER.exception("Error in event callback")
 
-            try:
-                self._callback(item)
-            except Exception as exc:
-                LOGGER.warning("Error in event callback: %s", exc)
-
-
-def _remaining(start_time: float, timeout: float) -> float:
-    """Returns the remaining time until the timeout expires."""
-    return max(0.0, timeout - (time.monotonic() - start_time))
+                if self._closed.is_set():
+                    return
+        finally:
+            with self._lock:
+                self._thread = None

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -167,6 +167,8 @@ class EventDispatcher:
                 )
                 _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
             except queue.Full:
+                # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as _closed.
+                # Not much we can do about it, but at least we won't leave the thread running.
                 pass
             finally:
                 self._stop_worker(timeout=_remaining(start_time, timeout))

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -170,7 +170,7 @@ class EventDispatcher:
                 )
                 _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
             except queue.Full:
-                # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as _closed.
+                # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as ``_closed``.
                 # Not much we can do about it, but at least we won't leave the thread running.
                 pass
             finally:
@@ -206,6 +206,13 @@ class EventDispatcher:
     def _enqueue_event(
         self, event: Union[BaseEvent, _Shutdown], timeout: float
     ) -> None:
+        """Enqueues an event to be delivered to the callback.  If the queue is full, the
+        event is dropped and counted.  If the dispatcher has been closed, the event is
+        ignored.
+
+        The caller will wait for at most ``timeout`` seconds to enqueue the event.
+        Caller must hold ``self._lock``.
+        """
         if (
             isinstance(event, UnleashEvent)
             and event.event_type is UnleashEventType.READY
@@ -230,7 +237,7 @@ class EventDispatcher:
 
         It blocks until an element is available."""
         while True:
-            item = self._queue.get()
+            item: _QueueItem = self._queue.get()
 
             if isinstance(item, _Shutdown):
                 item.done.set()

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -147,34 +147,43 @@ class EventDispatcher:
                 self._maybe_warn_about_full_queue()
 
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
-        """
-        close() signals the dispatcher to stop. It enqueues a Shutdown sentinel to the queue, and waits
-        for its signal to be set. The worker thread will eventually get to the sentinel, set its ``done``
-        signal, which will wake this thread and allow it to join the worker thread.
-
-        Even if the Shutdown sentinel cannot be enqueued, the worker thread will still be stopped and the dispatcher marked as closed.
-        """
+        thread: Optional[threading.Thread]
+        start_time = time.monotonic()
         with self._lock:
             if self._closed:
                 return
 
             self._closed = True
+            thread = self._thread
 
-            start_time = time.monotonic()
+        if thread is None:
+            return
+
+        if threading.current_thread() is thread:
             try:
-                if self._thread:
-                    shutdown_signal = self._signal_shutdown(
-                        timeout=_remaining(start_time, timeout)
-                    )
-                    _ = shutdown_signal.done.wait(
-                        timeout=_remaining(start_time, timeout)
-                    )
+                self._queue.put(item=_Shutdown(), timeout=0)
+                return
             except queue.Full:
                 # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as ``_closed``.
                 # Not much we can do about it, but at least we won't leave the thread running.
                 pass
-            finally:
-                self._stop_worker(timeout=_remaining(start_time, timeout))
+
+        shutdown_signal: Optional[_Shutdown] = None
+        try:
+            try:
+                shutdown_signal = self._signal_shutdown(
+                    timeout=_remaining(start_time, timeout)
+                )
+            except queue.Full:
+                shutdown_signal = None
+
+            if shutdown_signal is not None:
+                _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
+        finally:
+            thread.join(timeout=_remaining(start_time, timeout))
+            with self._lock:
+                if self._thread is thread and not thread.is_alive():
+                    self._thread = None
 
     def _signal_shutdown(self, timeout: float) -> _Shutdown:
         """Signals the worker to stop draining and exit.  Caller must hold ``self._lock``."""

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -67,9 +67,6 @@ class UnleashFetchedEvent(BaseEvent):
         return self._parsed_payload
 
 
-DEFAULT_MAX_QUEUE_SIZE = 10_000
-DEFAULT_TIMEOUT = 2.0
-
 _SHUTDOWN = object()
 
 
@@ -89,6 +86,10 @@ class EventDispatcherOptions:
     """
     Configuration for the event dispatcher.  Intentionally empty for now.
     """
+
+
+DEFAULT_MAX_QUEUE_SIZE = 10_000
+DEFAULT_TIMEOUT = 2.0
 
 
 class EventDispatcher:
@@ -203,8 +204,7 @@ class EventDispatcher:
 
             if should_warn:
                 LOGGER.warning(
-                    "Unleash event queue is full, events are being dropped. "
-                    "This usually means the event callback is too slow."
+                    "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
                 )
             else:
                 LOGGER.debug("Event was dropped because queue is full.")

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -1,12 +1,10 @@
-from threading import Event
-
-
 import queue
 import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from json import loads
+from threading import Event
 from typing import Callable, Optional, Union
 from uuid import UUID
 
@@ -118,6 +116,9 @@ class EventDispatcher:
         self._ready_fired = False
         self._closed = False
 
+    def __del__(self):
+        self.close()
+    
     @property
     def dropped_events(self) -> int:
         """
@@ -131,12 +132,11 @@ class EventDispatcher:
         self, event: BaseEvent, timeout: float = DEFAULT_PUT_TIMEOUT
     ) -> None:
         """
-        Queues an event for delivery.  Never blocks the caller.  READY events after
-        the first one are ignored.
+        Enqueues an event to be delivered to the callback.  If the queue is full, the
+        event is dropped and counted.  If the dispatcher has been closed, the event is
+        ignored.  This method is thread safe.
 
-        The closed check and the enqueue happen under one lock, so an event that gets
-        past the check is always queued ahead of a concurrent ``close``, never behind
-        its shutdown sentinel where the worker would never see it.
+        The caller will wait for at most ``DEFAULT_PUT_TIMEOUT`` seconds to enqueue the event.
         """
         with self._lock:
             if self._closed:
@@ -157,6 +157,7 @@ class EventDispatcher:
         with self._lock:
             if self._closed:
                 return
+
             self._closed = True
 
             start_time = time.monotonic()

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -118,7 +118,7 @@ class EventDispatcher:
 
     def __del__(self):
         self.close()
-    
+
     @property
     def dropped_events(self) -> int:
         """
@@ -151,8 +151,11 @@ class EventDispatcher:
 
     def close(self, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
-        Stops the dispatcher.  Events already queued are delivered first, but only
-        for as long as the timeout allows.  Calling this more than once is a no-op.
+        close() signals the dispatcher to stop. It enqueues a Shutdown sentinel to the queue, and waits
+        for its signal to be set. The worker thread will eventually get to the sentinal, set its ``done``
+        signal, which will wake this thread and allow it to join the worker thread.
+
+        Even if the Shutdown sentinel cannot be enqueued, the worker thread will still be stopped and the dispatcher marked as closed.
         """
         with self._lock:
             if self._closed:

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -165,10 +165,13 @@ class EventDispatcher:
 
             start_time = time.monotonic()
             try:
-                shutdown_signal = self._signal_shutdown(
-                    timeout=_remaining(start_time, timeout)
-                )
-                _ = shutdown_signal.done.wait(timeout=_remaining(start_time, timeout))
+                if self._thread:
+                    shutdown_signal = self._signal_shutdown(
+                        timeout=_remaining(start_time, timeout)
+                    )
+                    _ = shutdown_signal.done.wait(
+                        timeout=_remaining(start_time, timeout)
+                    )
             except queue.Full:
                 # Even if Shutdown could not be queued, we'll still stop the worker thread and mark as ``_closed``.
                 # Not much we can do about it, but at least we won't leave the thread running.

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -234,6 +234,7 @@ class EventDispatcher:
             LOGGER.warning(
                 "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
             )
+            self._warned_about_full_queue = True
 
     def _run(self) -> None:
         """_run is the inifinite loop that drains the queue of events.

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from json import loads
-from typing import Any, Callable, Optional
+from typing import Callable, Optional, Union
 from uuid import UUID
 
 from UnleashClient.utils import LOGGER
@@ -67,7 +67,18 @@ class UnleashFetchedEvent(BaseEvent):
         return self._parsed_payload
 
 
-_SHUTDOWN = object()
+class _Shutdown:
+    """
+    Sentinel that tells the worker to stop draining and exit.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<_SHUTDOWN>"
+
+
+_SHUTDOWN = _Shutdown()
 
 
 class _FlushMarker:
@@ -80,6 +91,8 @@ class _FlushMarker:
     def __init__(self) -> None:
         self.done = threading.Event()
 
+
+_QueueItem = Union[BaseEvent, _Shutdown, _FlushMarker]
 
 DEFAULT_MAX_QUEUE_SIZE = 10_000
 DEFAULT_TIMEOUT = 2.0
@@ -106,7 +119,7 @@ class EventDispatcher:
         max_size: int = DEFAULT_MAX_QUEUE_SIZE,
     ) -> None:
         self._callback = callback
-        self._queue: queue.Queue = queue.Queue(maxsize=max_size)
+        self._queue: queue.Queue[_QueueItem] = queue.Queue(maxsize=max_size)
         self._lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
         self._dropped = 0
@@ -181,7 +194,7 @@ class EventDispatcher:
 
         thread.join(max(0.0, deadline - time.monotonic()))
 
-    def _enqueue(self, item: Any) -> None:
+    def _enqueue(self, item: _QueueItem) -> None:
         self._ensure_worker()
 
         try:
@@ -219,12 +232,12 @@ class EventDispatcher:
         while True:
             item = self._queue.get()
 
-            if item is _SHUTDOWN:
-                return
-
             if isinstance(item, _FlushMarker):
                 item.done.set()
                 continue
+
+            if isinstance(item, _Shutdown):
+                return
 
             try:
                 self._callback(item)

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -81,13 +81,6 @@ class _FlushMarker:
         self.done = threading.Event()
 
 
-@dataclass
-class EventDispatcherOptions:
-    """
-    Configuration for the event dispatcher.  Intentionally empty for now.
-    """
-
-
 DEFAULT_MAX_QUEUE_SIZE = 10_000
 DEFAULT_TIMEOUT = 2.0
 
@@ -104,18 +97,15 @@ class EventDispatcher:
     delivered once, no matter how many connectors emit it or from which thread.
 
     :param callback: Function to hand events to.
-    :param options: Optional configuration object.
     :param max_size: Maximum number of events to hold before dropping.
     """
 
     def __init__(
         self,
         callback: Callable[[BaseEvent], None],
-        options: Optional[EventDispatcherOptions] = None,
         max_size: int = DEFAULT_MAX_QUEUE_SIZE,
     ) -> None:
         self._callback = callback
-        self._options = options or EventDispatcherOptions()
         self._queue: queue.Queue = queue.Queue(maxsize=max_size)
         self._lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -140,6 +140,10 @@ class EventDispatcher:
         """
         Queues an event for delivery.  Never blocks the caller.  READY events after
         the first one are ignored.
+
+        The closed check and the enqueue happen under one lock, so an event that gets
+        past the check is always queued ahead of a concurrent ``close``, never behind
+        its shutdown sentinel where the worker would never see it.
         """
         with self._lock:
             if self._closed:
@@ -150,7 +154,22 @@ class EventDispatcher:
                     return
                 self._ready_fired = True
 
-        self._enqueue(event)
+            self._start_worker()
+
+            try:
+                self._queue.put_nowait(event)
+                return
+            except queue.Full:
+                self._dropped += 1
+                should_warn = not self._warned_about_full_queue
+                self._warned_about_full_queue = True
+
+        if should_warn:
+            LOGGER.warning(
+                "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
+            )
+        else:
+            LOGGER.debug("Event was dropped because queue is full.")
 
     def flush(self, timeout: float = DEFAULT_TIMEOUT) -> bool:
         """
@@ -194,36 +213,15 @@ class EventDispatcher:
 
         thread.join(max(0.0, deadline - time.monotonic()))
 
-    def _enqueue(self, item: _QueueItem) -> None:
-        self._ensure_worker()
-
-        try:
-            self._queue.put_nowait(item)
-        except queue.Full:
-            with self._lock:
-                self._dropped += 1
-                should_warn = not self._warned_about_full_queue
-                self._warned_about_full_queue = True
-
-            if should_warn:
-                LOGGER.warning(
-                    "Unleash event queue is full, events are being dropped. This usually means the event callback is too slow."
-                )
-            else:
-                LOGGER.debug("Event was dropped because queue is full.")
-
-    def _ensure_worker(self) -> None:
-        """Initializes a worker if one is not started. Further calls to _ensure_worker are no-ops."""
+    def _start_worker(self) -> None:
+        """Starts a worker if one is not running.  Caller must hold ``self._lock``."""
         if self._thread is not None:
             return
 
-        with self._lock:
-            if self._thread is not None or self._closed:
-                return
-            self._thread = threading.Thread(
-                target=self._run, name="UnleashEventDispatcher", daemon=True
-            )
-            self._thread.start()
+        self._thread = threading.Thread(
+            target=self._run, name="UnleashEventDispatcher", daemon=True
+        )
+        self._thread.start()
 
     def _run(self) -> None:
         """_run is the inifinite loop that drains the queue of events.
@@ -237,9 +235,25 @@ class EventDispatcher:
                 continue
 
             if isinstance(item, _Shutdown):
+                self._release_flush_markers()
                 return
 
             try:
                 self._callback(item)
             except Exception as exc:
                 LOGGER.warning("Error in event callback: %s", exc)
+
+    def _release_flush_markers(self) -> None:
+        """
+        Wakes anything that raced close() and landed behind the shutdown sentinel,
+        rather than leaving it blocked for its full timeout.  Events found back there
+        are discarded: close() only promises to deliver what was queued before it.
+        """
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                return
+
+            if isinstance(item, _FlushMarker):
+                item.done.set()

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -90,12 +90,13 @@ class EventDispatcher:
         self._lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
         self._closed = threading.Event()
+        self._closing = threading.Event()
         self._dropped = 0
         self._ready_delivered = False
 
     def emit_event(self, event: BaseEvent) -> None:
         with self._lock:
-            if self._closed.is_set():
+            if self._closed.is_set() or self._closing.is_set():
                 return
 
             self._start_worker()
@@ -128,7 +129,8 @@ class EventDispatcher:
             if self._closed.is_set():
                 return
 
-            self._closed.set()
+            self._closing.set()
+
             thread = self._thread
 
             if thread is None:
@@ -141,6 +143,8 @@ class EventDispatcher:
 
         if threading.current_thread() is not thread:
             thread.join(timeout)
+
+        self._closed.set()
 
     def _start_worker(self) -> None:
         if self._thread is not None:
@@ -155,7 +159,7 @@ class EventDispatcher:
 
     def _run(self) -> None:
         try:
-            while True:
+            while not self._closing.is_set():
                 item: Union[_ShutdownMarker, BaseEvent] = self._queue.get()
 
                 if isinstance(item, _ShutdownMarker):

--- a/UnleashClient/events.py
+++ b/UnleashClient/events.py
@@ -116,9 +116,6 @@ class EventDispatcher:
         self._ready_fired = False
         self._closed = False
 
-    def __del__(self):
-        self.close()
-
     @property
     def dropped_events(self) -> int:
         """

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -306,3 +306,94 @@ def test_emit_event_after_close_is_a_no_op(
     dispatcher.emit_event(ready_event())
 
     assert [event.feature_name for event in received] == ["before"]
+
+
+def test_event_accepted_while_closing_is_still_delivered(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    """
+    This test is dense. What the test does is to manufacture the
+    race condition between emit_event() and close(). In other words, the window between 
+    emit_event accepting an event and queueing it is nanoseconds
+    wide, too narrow to hit by chance. The gate below widens it by freezing the
+    emitter between those two steps.
+
+    close() then runs on another thread while the emitter is frozen.  If it can take
+    the lock, it queues its shutdown sentinel ahead of the event, the worker exits on
+    the sentinel, and the event is never delivered.  Holding the lock across the whole
+    enqueue blocks close() until the event is queued.
+    """
+    received: list[UnleashEvent] = []
+    dispatcher = dispatcher_factory(received.append)
+
+    dispatcher.emit_event(flag_event("warmup")) # First emission lazily creates worked thread.
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+
+    inside_put = threading.Event()
+    release = threading.Event()
+    real_put_nowait = dispatcher._queue.put_nowait
+
+    def gated_put_nowait(item):
+        # emit_event has accepted the event but not queued it yet.
+        inside_put.set()
+        _ = release.wait(timeout=WAIT_TIMEOUT)
+        real_put_nowait(item)
+
+    dispatcher._queue.put_nowait = gated_put_nowait # "manufacture" a slow "put_nowait"
+
+    emitter = threading.Thread(target=lambda: dispatcher.emit_event(flag_event("racy")))
+    emitter.start()
+    assert inside_put.wait(timeout=WAIT_TIMEOUT)
+
+    closer = threading.Thread(target=lambda: dispatcher.close(timeout=WAIT_TIMEOUT))
+    closer.start()
+    time.sleep(0.1)  # ample time for an unsynchronized close() to queue the sentinel
+
+    release.set()
+    emitter.join(timeout=WAIT_TIMEOUT)
+    closer.join(timeout=WAIT_TIMEOUT)
+
+    # assert that "racy" was not queued after _Shutdown
+    assert [event.feature_name for event in received] == ["warmup", "racy"]
+
+
+def test_flush_queued_behind_shutdown_is_released(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    """
+    [_SHUTDOWN, marker] is a genuinely reachable queue state during a concurrent close() + flush().
+
+    This test exercises that case, ensuring that anyone waiting for marker to be released
+    is not left hanging.
+
+    A flush that raced close() and landed behind the sentinel must be woken when the
+    worker exits, instead of blocking for its whole timeout.
+    """
+    entered = threading.Event()
+    release = threading.Event()
+
+    def callback(_event: UnleashEvent):
+        entered.set()
+        _ = release.wait(timeout=WAIT_TIMEOUT)
+
+    dispatcher = dispatcher_factory(callback)
+
+    dispatcher.emit_event(flag_event())
+    assert entered.wait(timeout=WAIT_TIMEOUT)
+
+    closer = threading.Thread(target=lambda: dispatcher.close(timeout=WAIT_TIMEOUT))
+    closer.start()
+    time.sleep(0.1)  # let the sentinel land behind the wedged event
+
+    flushed: list[bool] = []
+    flusher = threading.Thread(
+        target=lambda: flushed.append(dispatcher.flush(timeout=WAIT_TIMEOUT))
+    )
+    flusher.start()
+    time.sleep(0.1)  # ...and the flush marker land behind the sentinel
+
+    release.set()
+    flusher.join(timeout=WAIT_TIMEOUT)
+    closer.join(timeout=WAIT_TIMEOUT)
+
+    assert flushed == [True]

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -2,8 +2,7 @@ import json
 import threading
 import time
 import uuid
-from collections.abc import Iterator
-from typing import Callable
+from typing import Callable, Iterator
 
 import pytest
 

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -1,0 +1,288 @@
+import json
+import threading
+import time
+import uuid
+
+import pytest
+
+from UnleashClient.events import (
+    EventDispatcher,
+    EventDispatcherOptions,
+    UnleashEvent,
+    UnleashEventType,
+    UnleashFetchedEvent,
+    UnleashReadyEvent,
+)
+
+# Generous enough to never trip on a loaded CI box, short enough that a genuine
+# hang fails the test instead of the suite.
+WAIT_TIMEOUT = 5
+
+
+def flag_event(feature_name: str = "testFlag") -> UnleashEvent:
+    return UnleashEvent(
+        event_type=UnleashEventType.FEATURE_FLAG,
+        event_id=uuid.uuid4(),
+        context={},
+        enabled=True,
+        feature_name=feature_name,
+    )
+
+
+def variant_event(feature_name: str = "testVariations") -> UnleashEvent:
+    return UnleashEvent(
+        event_type=UnleashEventType.VARIANT,
+        event_id=uuid.uuid4(),
+        context={},
+        enabled=True,
+        feature_name=feature_name,
+        variant="VarA",
+    )
+
+
+def ready_event() -> UnleashReadyEvent:
+    return UnleashReadyEvent(
+        event_type=UnleashEventType.READY,
+        event_id=uuid.uuid4(),
+    )
+
+
+def fetched_event() -> UnleashFetchedEvent:
+    return UnleashFetchedEvent(
+        event_type=UnleashEventType.FETCHED,
+        event_id=uuid.uuid4(),
+        raw_features=json.dumps({"features": [{"name": "testFlag"}]}),
+    )
+
+
+@pytest.fixture()
+def dispatcher_factory():
+    """
+    Builds dispatchers and guarantees they're torn down, so a wedged worker thread
+    can't leak into the next test.
+    """
+    created = []
+
+    def _build(*args, **kwargs) -> EventDispatcher:
+        dispatcher = EventDispatcher(*args, **kwargs)
+        created.append(dispatcher)
+        return dispatcher
+
+    yield _build
+
+    for dispatcher in created:
+        dispatcher.close(timeout=1)
+
+
+def test_emit_event_does_not_block_the_caller(dispatcher_factory):
+    entered = threading.Event()
+    release = threading.Event()
+    received = []
+
+    def callback(event):
+        entered.set()
+        release.wait(timeout=WAIT_TIMEOUT)
+        received.append(event)
+
+    dispatcher = dispatcher_factory(callback)
+
+    # Wedge the worker inside the callback, then keep emitting.
+    dispatcher.emit_event(flag_event())
+    assert entered.wait(timeout=WAIT_TIMEOUT)
+
+    start = time.monotonic()
+    for index in range(100):
+        dispatcher.emit_event(flag_event(str(index)))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1
+
+    release.set()
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    assert len(received) == 101
+
+
+def test_events_are_delivered_in_order(dispatcher_factory):
+    received = []
+    dispatcher = dispatcher_factory(received.append)
+
+    dispatcher.emit_event(flag_event("one"))
+    dispatcher.emit_event(flag_event("two"))
+    dispatcher.emit_event(flag_event("three"))
+
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    assert [event.feature_name for event in received] == ["one", "two", "three"]
+
+
+def test_every_event_type_reaches_the_callback(dispatcher_factory):
+    received = []
+    dispatcher = dispatcher_factory(received.append, EventDispatcherOptions())
+
+    dispatcher.emit_event(ready_event())
+    dispatcher.emit_event(fetched_event())
+    dispatcher.emit_event(flag_event())
+    dispatcher.emit_event(variant_event())
+
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    assert [event.event_type for event in received] == [
+        UnleashEventType.READY,
+        UnleashEventType.FETCHED,
+        UnleashEventType.FEATURE_FLAG,
+        UnleashEventType.VARIANT,
+    ]
+
+
+def test_ready_event_is_emitted_at_most_once(dispatcher_factory):
+    received = []
+    dispatcher = dispatcher_factory(received.append)
+
+    thread_count = 8
+    start_line = threading.Barrier(thread_count)
+
+    def hammer():
+        start_line.wait(timeout=WAIT_TIMEOUT)
+        for _ in range(50):
+            dispatcher.emit_event(ready_event())
+
+    threads = [threading.Thread(target=hammer) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=WAIT_TIMEOUT)
+
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    assert len(received) == 1
+    assert received[0].event_type is UnleashEventType.READY
+
+
+def test_callback_exception_does_not_kill_the_worker(dispatcher_factory):
+    received = []
+
+    def callback(event):
+        if event.feature_name == "boom":
+            raise ValueError("callback blew up")
+        received.append(event)
+
+    dispatcher = dispatcher_factory(callback)
+
+    dispatcher.emit_event(flag_event("boom"))
+    dispatcher.emit_event(flag_event("survivor"))
+
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    assert [event.feature_name for event in received] == ["survivor"]
+
+
+def test_events_are_dropped_when_the_queue_is_full(dispatcher_factory):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def callback(event):
+        entered.set()
+        release.wait(timeout=WAIT_TIMEOUT)
+
+    dispatcher = dispatcher_factory(callback, max_size=2)
+
+    # The worker parks inside the callback, so the queue can only ever hold two.
+    dispatcher.emit_event(flag_event())
+    assert entered.wait(timeout=WAIT_TIMEOUT)
+
+    for _ in range(10):
+        dispatcher.emit_event(flag_event())
+
+    assert dispatcher.dropped_events == 8
+
+    release.set()
+
+
+def test_flush_times_out_when_the_callback_hangs(dispatcher_factory):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def callback(event):
+        entered.set()
+        release.wait(timeout=WAIT_TIMEOUT)
+
+    dispatcher = dispatcher_factory(callback)
+
+    dispatcher.emit_event(flag_event())
+    assert entered.wait(timeout=WAIT_TIMEOUT)
+
+    assert dispatcher.flush(timeout=0.2) is False
+
+    release.set()
+
+
+def test_flush_is_a_no_op_before_the_first_event(dispatcher_factory):
+    dispatcher = dispatcher_factory(lambda event: None)
+
+    assert dispatcher._thread is None
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+
+    dispatcher.emit_event(flag_event())
+
+    assert dispatcher._thread is not None
+
+
+def test_close_drains_pending_events(dispatcher_factory):
+    received = []
+    gate = threading.Event()
+
+    def callback(event):
+        gate.wait(timeout=WAIT_TIMEOUT)
+        received.append(event)
+
+    dispatcher = dispatcher_factory(callback)
+
+    for index in range(5):
+        dispatcher.emit_event(flag_event(str(index)))
+
+    gate.set()
+    dispatcher.close(timeout=WAIT_TIMEOUT)
+
+    assert [event.feature_name for event in received] == ["0", "1", "2", "3", "4"]
+
+
+def test_close_is_idempotent(dispatcher_factory):
+    received = []
+    dispatcher = dispatcher_factory(received.append)
+
+    dispatcher.emit_event(flag_event())
+    dispatcher.close(timeout=WAIT_TIMEOUT)
+    dispatcher.close(timeout=WAIT_TIMEOUT)
+
+    assert len(received) == 1
+
+
+def test_close_returns_even_when_the_callback_hangs(dispatcher_factory):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def callback(event):
+        entered.set()
+        release.wait(timeout=WAIT_TIMEOUT)
+
+    dispatcher = dispatcher_factory(callback, max_size=1)
+
+    dispatcher.emit_event(flag_event())
+    assert entered.wait(timeout=WAIT_TIMEOUT)
+    dispatcher.emit_event(flag_event())  # fills the queue, so the sentinel can't fit
+
+    start = time.monotonic()
+    dispatcher.close(timeout=0.2)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2
+
+    release.set()
+
+
+def test_emit_event_after_close_is_a_no_op(dispatcher_factory):
+    received = []
+    dispatcher = dispatcher_factory(received.append)
+
+    dispatcher.emit_event(flag_event("before"))
+    dispatcher.close(timeout=WAIT_TIMEOUT)
+    dispatcher.emit_event(flag_event("after"))
+    dispatcher.emit_event(ready_event())
+
+    assert [event.feature_name for event in received] == ["before"]

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -7,7 +7,6 @@ import pytest
 
 from UnleashClient.events import (
     EventDispatcher,
-    EventDispatcherOptions,
     UnleashEvent,
     UnleashEventType,
     UnleashFetchedEvent,
@@ -116,7 +115,7 @@ def test_events_are_delivered_in_order(dispatcher_factory):
 
 def test_every_event_type_reaches_the_callback(dispatcher_factory):
     received = []
-    dispatcher = dispatcher_factory(received.append, EventDispatcherOptions())
+    dispatcher = dispatcher_factory(received.append)
 
     dispatcher.emit_event(ready_event())
     dispatcher.emit_event(fetched_event())

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -2,6 +2,8 @@ import json
 import threading
 import time
 import uuid
+from collections.abc import Iterator
+from typing import Callable
 
 import pytest
 
@@ -55,12 +57,12 @@ def fetched_event() -> UnleashFetchedEvent:
 
 
 @pytest.fixture()
-def dispatcher_factory():
+def dispatcher_factory() -> Iterator[Callable[..., EventDispatcher]]:
     """
     Builds dispatchers and guarantees they're torn down, so a wedged worker thread
     can't leak into the next test.
     """
-    created = []
+    created: list[EventDispatcher] = []
 
     def _build(*args, **kwargs) -> EventDispatcher:
         dispatcher = EventDispatcher(*args, **kwargs)
@@ -73,14 +75,16 @@ def dispatcher_factory():
         dispatcher.close(timeout=1)
 
 
-def test_emit_event_does_not_block_the_caller(dispatcher_factory):
+def test_emit_event_does_not_block_the_caller(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     entered = threading.Event()
     release = threading.Event()
-    received = []
+    received: list[UnleashEvent] = []
 
-    def callback(event):
+    def callback(event: UnleashEvent):
         entered.set()
-        release.wait(timeout=WAIT_TIMEOUT)
+        _ = release.wait(timeout=WAIT_TIMEOUT)
         received.append(event)
 
     dispatcher = dispatcher_factory(callback)
@@ -101,8 +105,10 @@ def test_emit_event_does_not_block_the_caller(dispatcher_factory):
     assert len(received) == 101
 
 
-def test_events_are_delivered_in_order(dispatcher_factory):
-    received = []
+def test_events_are_delivered_in_order(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
     dispatcher.emit_event(flag_event("one"))
@@ -113,8 +119,10 @@ def test_events_are_delivered_in_order(dispatcher_factory):
     assert [event.feature_name for event in received] == ["one", "two", "three"]
 
 
-def test_every_event_type_reaches_the_callback(dispatcher_factory):
-    received = []
+def test_every_event_type_reaches_the_callback(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
     dispatcher.emit_event(ready_event())
@@ -131,15 +139,17 @@ def test_every_event_type_reaches_the_callback(dispatcher_factory):
     ]
 
 
-def test_ready_event_is_emitted_at_most_once(dispatcher_factory):
-    received = []
+def test_ready_event_is_emitted_at_most_once(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
     thread_count = 8
     start_line = threading.Barrier(thread_count)
 
     def hammer():
-        start_line.wait(timeout=WAIT_TIMEOUT)
+        _ = start_line.wait(timeout=WAIT_TIMEOUT)
         for _ in range(50):
             dispatcher.emit_event(ready_event())
 
@@ -154,10 +164,12 @@ def test_ready_event_is_emitted_at_most_once(dispatcher_factory):
     assert received[0].event_type is UnleashEventType.READY
 
 
-def test_callback_exception_does_not_kill_the_worker(dispatcher_factory):
-    received = []
+def test_callback_exception_does_not_kill_the_worker(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    received: list[UnleashEvent] = []
 
-    def callback(event):
+    def callback(event: UnleashEvent):
         if event.feature_name == "boom":
             raise ValueError("callback blew up")
         received.append(event)
@@ -171,13 +183,15 @@ def test_callback_exception_does_not_kill_the_worker(dispatcher_factory):
     assert [event.feature_name for event in received] == ["survivor"]
 
 
-def test_events_are_dropped_when_the_queue_is_full(dispatcher_factory):
+def test_events_are_dropped_when_the_queue_is_full(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     entered = threading.Event()
     release = threading.Event()
 
-    def callback(event):
+    def callback(_event: UnleashEvent):
         entered.set()
-        release.wait(timeout=WAIT_TIMEOUT)
+        _ = release.wait(timeout=WAIT_TIMEOUT)
 
     dispatcher = dispatcher_factory(callback, max_size=2)
 
@@ -193,13 +207,15 @@ def test_events_are_dropped_when_the_queue_is_full(dispatcher_factory):
     release.set()
 
 
-def test_flush_times_out_when_the_callback_hangs(dispatcher_factory):
+def test_flush_times_out_when_the_callback_hangs(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     entered = threading.Event()
     release = threading.Event()
 
-    def callback(event):
+    def callback(event: UnleashEvent):
         entered.set()
-        release.wait(timeout=WAIT_TIMEOUT)
+        _ = release.wait(timeout=WAIT_TIMEOUT)
 
     dispatcher = dispatcher_factory(callback)
 
@@ -211,7 +227,9 @@ def test_flush_times_out_when_the_callback_hangs(dispatcher_factory):
     release.set()
 
 
-def test_flush_is_a_no_op_before_the_first_event(dispatcher_factory):
+def test_flush_is_a_no_op_before_the_first_event(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     dispatcher = dispatcher_factory(lambda event: None)
 
     assert dispatcher._thread is None
@@ -222,12 +240,14 @@ def test_flush_is_a_no_op_before_the_first_event(dispatcher_factory):
     assert dispatcher._thread is not None
 
 
-def test_close_drains_pending_events(dispatcher_factory):
+def test_close_drains_pending_events(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     received = []
     gate = threading.Event()
 
-    def callback(event):
-        gate.wait(timeout=WAIT_TIMEOUT)
+    def callback(event: UnleashEvent):
+        _ = gate.wait(timeout=WAIT_TIMEOUT)
         received.append(event)
 
     dispatcher = dispatcher_factory(callback)
@@ -241,8 +261,8 @@ def test_close_drains_pending_events(dispatcher_factory):
     assert [event.feature_name for event in received] == ["0", "1", "2", "3", "4"]
 
 
-def test_close_is_idempotent(dispatcher_factory):
-    received = []
+def test_close_is_idempotent(dispatcher_factory: Callable[..., EventDispatcher]):
+    received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
     dispatcher.emit_event(flag_event())
@@ -252,13 +272,15 @@ def test_close_is_idempotent(dispatcher_factory):
     assert len(received) == 1
 
 
-def test_close_returns_even_when_the_callback_hangs(dispatcher_factory):
+def test_close_returns_even_when_the_callback_hangs(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
     entered = threading.Event()
     release = threading.Event()
 
-    def callback(event):
+    def callback(_event: UnleashEvent):
         entered.set()
-        release.wait(timeout=WAIT_TIMEOUT)
+        _ = release.wait(timeout=WAIT_TIMEOUT)
 
     dispatcher = dispatcher_factory(callback, max_size=1)
 
@@ -275,8 +297,10 @@ def test_close_returns_even_when_the_callback_hangs(dispatcher_factory):
     release.set()
 
 
-def test_emit_event_after_close_is_a_no_op(dispatcher_factory):
-    received = []
+def test_emit_event_after_close_is_a_no_op(
+    dispatcher_factory: Callable[..., EventDispatcher],
+):
+    received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
     dispatcher.emit_event(flag_event("before"))

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -313,7 +313,7 @@ def test_event_accepted_while_closing_is_still_delivered(
 ):
     """
     This test is dense. What the test does is to manufacture the
-    race condition between emit_event() and close(). In other words, the window between 
+    race condition between emit_event() and close(). In other words, the window between
     emit_event accepting an event and queueing it is nanoseconds
     wide, too narrow to hit by chance. The gate below widens it by freezing the
     emitter between those two steps.
@@ -326,7 +326,9 @@ def test_event_accepted_while_closing_is_still_delivered(
     received: list[UnleashEvent] = []
     dispatcher = dispatcher_factory(received.append)
 
-    dispatcher.emit_event(flag_event("warmup")) # First emission lazily creates worked thread.
+    dispatcher.emit_event(
+        flag_event("warmup")
+    )  # First emission lazily creates worked thread.
     assert dispatcher.flush(timeout=WAIT_TIMEOUT)
 
     inside_put = threading.Event()
@@ -339,7 +341,7 @@ def test_event_accepted_while_closing_is_still_delivered(
         _ = release.wait(timeout=WAIT_TIMEOUT)
         real_put_nowait(item)
 
-    dispatcher._queue.put_nowait = gated_put_nowait # "manufacture" a slow "put_nowait"
+    dispatcher._queue.put_nowait = gated_put_nowait  # "manufacture" a slow "put_nowait"
 
     emitter = threading.Thread(target=lambda: dispatcher.emit_event(flag_event("racy")))
     emitter.start()

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -15,8 +15,6 @@ from UnleashClient.events import (
     UnleashReadyEvent,
 )
 
-# Generous enough to never trip on a loaded CI box, short enough that a genuine
-# hang fails the test instead of the suite.
 WAIT_TIMEOUT = 5
 
 

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -17,10 +17,16 @@ from tests.utilities.event_callbacks import (
     fetched_event,
     flag_event,
     ready_event,
+    ready_event_as_unleash_event,
     variant_event,
     worker_threads,
 )
-from UnleashClient.events import BaseEvent, EventDispatcher, UnleashEvent
+from UnleashClient.events import (
+    BaseEvent,
+    EventDispatcher,
+    UnleashEvent,
+    UnleashEventType,
+)
 
 # Budget for an operation that must not wait on the callback.  Generous enough to survive a
 # loaded CI box, tight enough to fail if the emitter ever starts blocking.
@@ -37,6 +43,13 @@ def sdk_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
         record.getMessage()
         for record in caplog.records
         if record.name == "UnleashClient" and record.levelno == logging.WARNING
+    ]
+
+
+def ready_deliveries(callback: RecorderCallback) -> List[BaseEvent]:
+    """READY events that reached the callback, in arrival order."""
+    return [
+        event for event in callback.events if event.event_type is UnleashEventType.READY
     ]
 
 
@@ -414,6 +427,69 @@ class TestBackpressure:
         dispatcher.close(timeout=WAIT_TIMEOUT)
 
         assert dispatcher.dropped_events == 1
+
+
+class TestReadyDeduplication:
+    """
+    The dispatcher promises READY is delivered once, however many connectors emit it.
+
+    close() is the synchronization point in these tests: the shutdown sentinel goes in at the
+    tail of a FIFO queue, so everything emitted before it has been handed to the callback by
+    the time close() returns.
+    """
+
+    def test_ready_is_delivered_once_however_many_connectors_emit_it(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        # The shape build_ready_callback emits, which is what connectors actually hand over.
+        for _ in range(3):
+            dispatcher.emit_event(ready_event())
+
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert len(ready_deliveries(callback)) == 1
+
+    def test_ready_carried_on_an_unleash_event_is_deduplicated(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        for _ in range(3):
+            dispatcher.emit_event(ready_event_as_unleash_event())
+
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert len(ready_deliveries(callback)) == 1
+
+    def test_a_ready_event_dropped_by_a_full_queue_is_still_delivered_later(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+
+        # Nowhere to put it, so this READY never reaches the callback.
+        dispatcher.emit_event(ready_event_as_unleash_event(), timeout=0)
+        assert dispatcher.dropped_events == 1
+
+        callback.release()
+        assert callback.wait_for(2)
+
+        # The queue has drained, and this emit is willing to wait for room anyway.
+        dispatcher.emit_event(ready_event_as_unleash_event(), timeout=WAIT_TIMEOUT)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert ready_deliveries(callback), (
+            "READY was dropped while the queue was full, and every later attempt was "
+            "suppressed, so it was never delivered at all"
+        )
 
 
 class TestFullQueueWarning:

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -440,6 +440,21 @@ class TestFullQueueWarning:
             message for message in sdk_warnings(caplog) if "queue is full" in message
         ]
 
+    def test_a_full_queue_is_warned_about_only_once(  # line 443
+        self,
+        dispatcher_factory: Callable[..., EventDispatcher],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.WARNING, logger="UnleashClient")
+
+        self._drop_events(dispatcher_factory, count=5)
+
+        # One warning about a saturated queue, not one per dropped event.
+        warnings = [
+            message for message in sdk_warnings(caplog) if "queue is full" in message
+        ]
+        assert len(warnings) == 1
+
 
 class TestCallbackErrorLogging:
     def test_a_callback_exception_is_logged_with_its_message(

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -591,6 +591,19 @@ class TestClose:
 
         assert elapsed < NON_BLOCKING_BUDGET
 
+    def test_close_returns_promptly_when_nothing_was_ever_emitted(  # line 594
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
+
+        start = time.monotonic()
+        dispatcher.close()  # the default timeout, which is what callers get
+        elapsed = time.monotonic() - start
+
+        # No event was ever emitted, so no worker was ever started and there is nothing
+        # for close() to wait on.
+        assert elapsed < NON_BLOCKING_BUDGET
+
     def test_emit_after_close_is_a_no_op(
         self, dispatcher_factory: Callable[..., EventDispatcher]
     ):

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 import time
-from typing import Callable, Iterator, List, Tuple
+from typing import Callable, Iterator, List, Optional, Tuple
 
 import pytest
 
@@ -9,8 +9,10 @@ from tests.utilities.event_callbacks import (
     DISPATCHER_THREAD_NAME,
     WAIT_TIMEOUT,
     BlockingCallback,
+    ClosingCallback,
     RaisingCallback,
     RecorderCallback,
+    ReentrantCallback,
     SlowCallback,
     fetched_event,
     flag_event,
@@ -18,11 +20,15 @@ from tests.utilities.event_callbacks import (
     variant_event,
     worker_threads,
 )
-from UnleashClient.events import EventDispatcher
+from UnleashClient.events import BaseEvent, EventDispatcher, UnleashEvent
 
 # Budget for an operation that must not wait on the callback.  Generous enough to survive a
 # loaded CI box, tight enough to fail if the emitter ever starts blocking.
 NON_BLOCKING_BUDGET = 0.5
+
+# Timeout handed to close() when a test needs to tell "returned promptly" apart from "waited out
+# the whole timeout".  Several times NON_BLOCKING_BUDGET, so the two can't be confused.
+CLOSE_TIMEOUT = 2.0
 
 
 def sdk_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
@@ -648,6 +654,55 @@ class TestClose:
         dispatcher.emit_event(flag_event())
 
         assert len(worker_threads()) == before
+
+    def test_a_callback_that_emits_does_not_stall_a_concurrent_close(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        def follow_up_once(event: BaseEvent) -> Optional[BaseEvent]:
+            """One follow-up, for the first event only, so the dispatcher can't feed itself."""
+            if (
+                isinstance(event, UnleashEvent)
+                and event.feature_name == "pins the worker"
+            ):
+                return flag_event("from the callback")
+            return None
+
+        callback = ReentrantCallback(follow_up_once, gated=True)
+        dispatcher = dispatcher_factory(callback)
+        callback.bind(dispatcher)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        # close() gets to run first and is already waiting on its sentinel by the time the timer
+        # lets the callback emit, which is the ordering this test is about.
+        unblock = threading.Timer(0.1, callback.release)
+        unblock.start()
+
+        start = time.monotonic()
+        dispatcher.close(timeout=CLOSE_TIMEOUT)
+        elapsed = time.monotonic() - start
+        unblock.join()
+
+        assert elapsed < NON_BLOCKING_BUDGET
+        assert callback.emitted.wait(timeout=WAIT_TIMEOUT)
+        assert callback.emit_duration is not None
+        assert callback.emit_duration < NON_BLOCKING_BUDGET
+
+    def test_closing_from_inside_the_callback_does_not_blow_up(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = ClosingCallback(timeout=CLOSE_TIMEOUT)
+        dispatcher = dispatcher_factory(callback)
+        callback.bind(dispatcher)
+
+        start = time.monotonic()
+        dispatcher.emit_event(flag_event())
+        assert callback.returned.wait(timeout=WAIT_TIMEOUT)
+        elapsed = time.monotonic() - start
+
+        assert callback.error is None
+        assert elapsed < NON_BLOCKING_BUDGET
 
     def test_two_threads_closing_at_once_both_return(
         self, dispatcher_factory: Callable[..., EventDispatcher]

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -78,7 +78,7 @@ def test_events_are_dropped_when_the_queue_is_full(
 def test_close_drains_pending_events(
     dispatcher_factory: Callable[..., EventDispatcher],
 ):
-    received = []
+    received: list[UnleashEvent] = []
     gate = threading.Event()
 
     def callback(event: UnleashEvent):

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -1,4 +1,3 @@
-import json
 import threading
 import time
 import uuid
@@ -10,7 +9,6 @@ from UnleashClient.events import (
     EventDispatcher,
     UnleashEvent,
     UnleashEventType,
-    UnleashFetchedEvent,
     UnleashReadyEvent,
 )
 
@@ -27,29 +25,10 @@ def flag_event(feature_name: str = "testFlag") -> UnleashEvent:
     )
 
 
-def variant_event(feature_name: str = "testVariations") -> UnleashEvent:
-    return UnleashEvent(
-        event_type=UnleashEventType.VARIANT,
-        event_id=uuid.uuid4(),
-        context={},
-        enabled=True,
-        feature_name=feature_name,
-        variant="VarA",
-    )
-
-
 def ready_event() -> UnleashReadyEvent:
     return UnleashReadyEvent(
         event_type=UnleashEventType.READY,
         event_id=uuid.uuid4(),
-    )
-
-
-def fetched_event() -> UnleashFetchedEvent:
-    return UnleashFetchedEvent(
-        event_type=UnleashEventType.FETCHED,
-        event_id=uuid.uuid4(),
-        raw_features=json.dumps({"features": [{"name": "testFlag"}]}),
     )
 
 
@@ -70,114 +49,6 @@ def dispatcher_factory() -> Iterator[Callable[..., EventDispatcher]]:
 
     for dispatcher in created:
         dispatcher.close(timeout=1)
-
-
-def test_emit_event_does_not_block_the_caller(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    entered = threading.Event()
-    release = threading.Event()
-    received: list[UnleashEvent] = []
-
-    def callback(event: UnleashEvent):
-        entered.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
-        received.append(event)
-
-    dispatcher = dispatcher_factory(callback)
-
-    # Wedge the worker inside the callback, then keep emitting.
-    dispatcher.emit_event(flag_event())
-    assert entered.wait(timeout=WAIT_TIMEOUT)
-
-    start = time.monotonic()
-    for index in range(100):
-        dispatcher.emit_event(flag_event(str(index)))
-    elapsed = time.monotonic() - start
-
-    assert elapsed < 1
-
-    release.set()
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-    assert len(received) == 101
-
-
-def test_events_are_delivered_in_order(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
-
-    dispatcher.emit_event(flag_event("one"))
-    dispatcher.emit_event(flag_event("two"))
-    dispatcher.emit_event(flag_event("three"))
-
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-    assert [event.feature_name for event in received] == ["one", "two", "three"]
-
-
-def test_every_event_type_reaches_the_callback(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
-
-    dispatcher.emit_event(ready_event())
-    dispatcher.emit_event(fetched_event())
-    dispatcher.emit_event(flag_event())
-    dispatcher.emit_event(variant_event())
-
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-    assert [event.event_type for event in received] == [
-        UnleashEventType.READY,
-        UnleashEventType.FETCHED,
-        UnleashEventType.FEATURE_FLAG,
-        UnleashEventType.VARIANT,
-    ]
-
-
-def test_ready_event_is_emitted_at_most_once(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
-
-    thread_count = 8
-    start_line = threading.Barrier(thread_count)
-
-    def hammer():
-        _ = start_line.wait(timeout=WAIT_TIMEOUT)
-        for _ in range(50):
-            dispatcher.emit_event(ready_event())
-
-    threads = [threading.Thread(target=hammer) for _ in range(thread_count)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join(timeout=WAIT_TIMEOUT)
-
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-    assert len(received) == 1
-    assert received[0].event_type is UnleashEventType.READY
-
-
-def test_callback_exception_does_not_kill_the_worker(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-
-    def callback(event: UnleashEvent):
-        if event.feature_name == "boom":
-            raise ValueError("callback blew up")
-        received.append(event)
-
-    dispatcher = dispatcher_factory(callback)
-
-    dispatcher.emit_event(flag_event("boom"))
-    dispatcher.emit_event(flag_event("survivor"))
-
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-    assert [event.feature_name for event in received] == ["survivor"]
 
 
 def test_events_are_dropped_when_the_queue_is_full(
@@ -202,39 +73,6 @@ def test_events_are_dropped_when_the_queue_is_full(
     assert dispatcher.dropped_events == 8
 
     release.set()
-
-
-def test_flush_times_out_when_the_callback_hangs(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    entered = threading.Event()
-    release = threading.Event()
-
-    def callback(event: UnleashEvent):
-        entered.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
-
-    dispatcher = dispatcher_factory(callback)
-
-    dispatcher.emit_event(flag_event())
-    assert entered.wait(timeout=WAIT_TIMEOUT)
-
-    assert dispatcher.flush(timeout=0.2) is False
-
-    release.set()
-
-
-def test_flush_is_a_no_op_before_the_first_event(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    dispatcher = dispatcher_factory(lambda event: None)
-
-    assert dispatcher._thread is None
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-
-    dispatcher.emit_event(flag_event())
-
-    assert dispatcher._thread is not None
 
 
 def test_close_drains_pending_events(
@@ -306,96 +144,3 @@ def test_emit_event_after_close_is_a_no_op(
     dispatcher.emit_event(ready_event())
 
     assert [event.feature_name for event in received] == ["before"]
-
-
-def test_event_accepted_while_closing_is_still_delivered(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    """
-    This test is dense. What the test does is to manufacture the
-    race condition between emit_event() and close(). In other words, the window between
-    emit_event accepting an event and queueing it is nanoseconds
-    wide, too narrow to hit by chance. The gate below widens it by freezing the
-    emitter between those two steps.
-
-    close() then runs on another thread while the emitter is frozen.  If it can take
-    the lock, it queues its shutdown sentinel ahead of the event, the worker exits on
-    the sentinel, and the event is never delivered.  Holding the lock across the whole
-    enqueue blocks close() until the event is queued.
-    """
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
-
-    dispatcher.emit_event(
-        flag_event("warmup")
-    )  # First emission lazily creates worked thread.
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
-
-    inside_put = threading.Event()
-    release = threading.Event()
-    real_put_nowait = dispatcher._queue.put_nowait
-
-    def gated_put_nowait(item):
-        # emit_event has accepted the event but not queued it yet.
-        inside_put.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
-        real_put_nowait(item)
-
-    dispatcher._queue.put_nowait = gated_put_nowait  # "manufacture" a slow "put_nowait"
-
-    emitter = threading.Thread(target=lambda: dispatcher.emit_event(flag_event("racy")))
-    emitter.start()
-    assert inside_put.wait(timeout=WAIT_TIMEOUT)
-
-    closer = threading.Thread(target=lambda: dispatcher.close(timeout=WAIT_TIMEOUT))
-    closer.start()
-    time.sleep(0.1)  # ample time for an unsynchronized close() to queue the sentinel
-
-    release.set()
-    emitter.join(timeout=WAIT_TIMEOUT)
-    closer.join(timeout=WAIT_TIMEOUT)
-
-    # assert that "racy" was not queued after _Shutdown
-    assert [event.feature_name for event in received] == ["warmup", "racy"]
-
-
-def test_flush_queued_behind_shutdown_is_released(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    """
-    [_SHUTDOWN, marker] is a genuinely reachable queue state during a concurrent close() + flush().
-
-    This test exercises that case, ensuring that anyone waiting for marker to be released
-    is not left hanging.
-
-    A flush that raced close() and landed behind the sentinel must be woken when the
-    worker exits, instead of blocking for its whole timeout.
-    """
-    entered = threading.Event()
-    release = threading.Event()
-
-    def callback(_event: UnleashEvent):
-        entered.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
-
-    dispatcher = dispatcher_factory(callback)
-
-    dispatcher.emit_event(flag_event())
-    assert entered.wait(timeout=WAIT_TIMEOUT)
-
-    closer = threading.Thread(target=lambda: dispatcher.close(timeout=WAIT_TIMEOUT))
-    closer.start()
-    time.sleep(0.1)  # let the sentinel land behind the wedged event
-
-    flushed: list[bool] = []
-    flusher = threading.Thread(
-        target=lambda: flushed.append(dispatcher.flush(timeout=WAIT_TIMEOUT))
-    )
-    flusher.start()
-    time.sleep(0.1)  # ...and the flush marker land behind the sentinel
-
-    release.set()
-    flusher.join(timeout=WAIT_TIMEOUT)
-    closer.join(timeout=WAIT_TIMEOUT)
-
-    assert flushed == [True]

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -1,35 +1,37 @@
+import logging
 import threading
 import time
-import uuid
-from typing import Callable, Iterator
+from typing import Callable, Iterator, List, Tuple
 
 import pytest
 
-from UnleashClient.events import (
-    EventDispatcher,
-    UnleashEvent,
-    UnleashEventType,
-    UnleashReadyEvent,
+from tests.utilities.event_callbacks import (
+    DISPATCHER_THREAD_NAME,
+    WAIT_TIMEOUT,
+    BlockingCallback,
+    RaisingCallback,
+    RecorderCallback,
+    SlowCallback,
+    fetched_event,
+    flag_event,
+    ready_event,
+    variant_event,
+    worker_threads,
 )
+from UnleashClient.events import EventDispatcher
 
-WAIT_TIMEOUT = 5
-
-
-def flag_event(feature_name: str = "testFlag") -> UnleashEvent:
-    return UnleashEvent(
-        event_type=UnleashEventType.FEATURE_FLAG,
-        event_id=uuid.uuid4(),
-        context={},
-        enabled=True,
-        feature_name=feature_name,
-    )
+# Budget for an operation that must not wait on the callback.  Generous enough to survive a
+# loaded CI box, tight enough to fail if the emitter ever starts blocking.
+NON_BLOCKING_BUDGET = 0.5
 
 
-def ready_event() -> UnleashReadyEvent:
-    return UnleashReadyEvent(
-        event_type=UnleashEventType.READY,
-        event_id=uuid.uuid4(),
-    )
+def sdk_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
+    """Messages the SDK logged at WARNING, in the order it logged them."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "UnleashClient" and record.levelno == logging.WARNING
+    ]
 
 
 @pytest.fixture()
@@ -37,110 +39,609 @@ def dispatcher_factory() -> Iterator[Callable[..., EventDispatcher]]:
     """
     Builds dispatchers and guarantees they're torn down, so a wedged worker thread
     can't leak into the next test.
-    """
-    created: list[EventDispatcher] = []
 
-    def _build(*args, **kwargs) -> EventDispatcher:
-        dispatcher = EventDispatcher(*args, **kwargs)
-        created.append(dispatcher)
+    Blocking callbacks are released before the close: a test that fails before its own
+    release() would otherwise leave the worker parked inside the callback.
+    """
+    created: List[Tuple[object, EventDispatcher]] = []
+
+    def _build(callback, *args, **kwargs) -> EventDispatcher:
+        dispatcher = EventDispatcher(callback, *args, **kwargs)
+        created.append((callback, dispatcher))
         return dispatcher
 
     yield _build
 
-    for dispatcher in created:
+    for callback, dispatcher in created:
+        release = getattr(callback, "release", None)
+        if callable(release):
+            release()
         dispatcher.close(timeout=1)
 
 
-def test_events_are_dropped_when_the_queue_is_full(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    entered = threading.Event()
-    release = threading.Event()
+class TestDelivery:
+    def test_an_emitted_event_reaches_the_callback(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
 
-    def callback(_event: UnleashEvent):
-        entered.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("testFlag"))
 
-    dispatcher = dispatcher_factory(callback, max_size=2)
+        assert callback.wait_for(1)
+        assert callback.feature_names == ["testFlag"]
 
-    # The worker parks inside the callback, so the queue can only ever hold two.
-    dispatcher.emit_event(flag_event())
-    assert entered.wait(timeout=WAIT_TIMEOUT)
+    def test_the_callback_is_handed_the_event_that_was_emitted(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+        event = flag_event()
 
-    for _ in range(10):
+        dispatcher.emit_event(event)
+
+        assert callback.wait_for(1)
+        assert callback.events[0] is event
+
+    def test_events_arrive_in_the_order_they_were_emitted(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        for index in range(20):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        assert callback.wait_for(20)
+        assert callback.feature_names == [str(index) for index in range(20)]
+
+    def test_every_kind_of_event_goes_to_the_same_callback(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+        emitted = [flag_event(), variant_event(), ready_event(), fetched_event()]
+
+        for event in emitted:
+            dispatcher.emit_event(event)
+
+        assert callback.wait_for(len(emitted))
+        assert callback.events == emitted
+
+    def test_emitting_does_not_wait_for_the_callback(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event())
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        start = time.monotonic()
+        dispatcher.emit_event(flag_event())
+        elapsed = time.monotonic() - start
+
+        assert elapsed < NON_BLOCKING_BUDGET
+        assert callback.call_count == 0  # still parked inside the first event
+
+    def test_a_slow_callback_never_slows_the_emitter(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = SlowCallback(delay=0.05)
+        dispatcher = dispatcher_factory(callback)
+
+        start = time.monotonic()
+        for _ in range(20):
+            dispatcher.emit_event(flag_event())
+        elapsed = time.monotonic() - start
+
+        # A full second of callback work, none of which the emitter should have paid for.
+        assert elapsed < NON_BLOCKING_BUDGET
+        assert callback.wait_for(20)
+
+
+class TestWorkerLifecycle:
+    def test_no_worker_runs_until_the_first_event(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        before = len(worker_threads())
+        dispatcher = dispatcher_factory(RecorderCallback())
+
+        assert len(worker_threads()) == before
+
         dispatcher.emit_event(flag_event())
 
-    assert dispatcher.dropped_events == 8
+        assert len(worker_threads()) == before + 1
 
-    release.set()
+    def test_one_worker_serves_every_event(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+        before = len(worker_threads())
+
+        for _ in range(10):
+            dispatcher.emit_event(flag_event())
+
+        assert callback.wait_for(10)
+        assert len(worker_threads()) == before + 1
+
+    def test_the_callback_never_runs_on_the_emitting_thread(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event())
+
+        assert callback.wait_for(1)
+        assert callback.threads == [DISPATCHER_THREAD_NAME]
+        assert threading.current_thread().name != DISPATCHER_THREAD_NAME
+
+    def test_the_worker_is_a_daemon_thread(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
+        before = set(worker_threads())
+
+        dispatcher.emit_event(flag_event())
+
+        (worker,) = set(worker_threads()) - before
+        assert worker.daemon is True
+
+    def test_close_leaves_no_worker_behind(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
+        before = set(worker_threads())
+        dispatcher.emit_event(flag_event())
+        (worker,) = set(worker_threads()) - before
+
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert not worker.is_alive()
+
+    def test_a_raising_callback_does_not_kill_the_worker(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RaisingCallback(times=1)
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event("explodes"))
+        dispatcher.emit_event(flag_event("survives"))
+
+        assert callback.wait_for(2)
+        assert callback.feature_names == ["explodes", "survives"]
+
+    def test_the_worker_outlives_a_callback_that_always_raises(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RaisingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        for index in range(50):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        assert callback.wait_for(50)
+        assert callback.feature_names == [str(index) for index in range(50)]
+
+    def test_a_callback_exception_never_reaches_the_emitter(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RaisingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event())
+
+        assert callback.wait_for(1)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
 
 
-def test_close_drains_pending_events(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-    gate = threading.Event()
+class TestBackpressure:
+    """
+    Every test here pins the worker inside a BlockingCallback first.  Once ``entered`` is set the
+    worker has taken its event off the queue and gone to sleep, so the queue is empty and its
+    depth from then on is exactly what the test put there.
+    """
 
-    def callback(event: UnleashEvent):
-        _ = gate.wait(timeout=WAIT_TIMEOUT)
-        received.append(event)
+    def test_no_events_are_dropped_before_anything_is_emitted(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
 
-    dispatcher = dispatcher_factory(callback)
+        assert dispatcher.dropped_events == 0
 
-    for index in range(5):
-        dispatcher.emit_event(flag_event(str(index)))
+    def test_nothing_is_dropped_when_the_callback_keeps_up(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback, max_size=100)
 
-    gate.set()
-    dispatcher.close(timeout=WAIT_TIMEOUT)
+        for index in range(50):
+            dispatcher.emit_event(flag_event(str(index)))
 
-    assert [event.feature_name for event in received] == ["0", "1", "2", "3", "4"]
+        assert callback.wait_for(50)
+        assert dispatcher.dropped_events == 0
+
+    def test_events_beyond_capacity_are_dropped(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=3)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        for index in range(10):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        # Three fit in the queue; the other seven have nowhere to go.
+        assert dispatcher.dropped_events == 7
+
+    def test_dropped_events_are_never_delivered(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=2)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        for index in range(10):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        callback.release()
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert callback.feature_names == ["pins the worker", "0", "1"]
+        assert dispatcher.dropped_events == 8
+
+    def test_the_queue_takes_events_again_once_the_callback_drains(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=2)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        for index in range(5):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        assert dispatcher.dropped_events == 3
+
+        callback.release()
+        assert callback.wait_for(3)
+
+        # There is room again, and these emits are willing to wait for it.
+        for index in range(5):
+            dispatcher.emit_event(flag_event("after"), timeout=WAIT_TIMEOUT)
+
+        assert callback.wait_for(8)
+        assert dispatcher.dropped_events == 3
+
+    def test_emit_gives_up_after_its_own_timeout(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+
+        start = time.monotonic()
+        dispatcher.emit_event(flag_event("nowhere to go"), timeout=0.3)
+        elapsed = time.monotonic() - start
+
+        assert 0.3 <= elapsed < 0.3 + NON_BLOCKING_BUDGET
+        assert dispatcher.dropped_events == 1
+
+    def test_emit_waits_for_room_when_given_a_generous_timeout(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+
+        # The only thing that can free a slot, and it won't for another 200ms.
+        unblock = threading.Timer(0.2, callback.release)
+        unblock.start()
+
+        start = time.monotonic()
+        dispatcher.emit_event(flag_event("waits for room"), timeout=WAIT_TIMEOUT)
+        elapsed = time.monotonic() - start
+        unblock.join()
+
+        assert elapsed >= 0.1
+        assert dispatcher.dropped_events == 0
+        assert callback.wait_for(3)
+        assert callback.feature_names == [
+            "pins the worker",
+            "fills the queue",
+            "waits for room",
+        ]
+
+    def test_nothing_is_dropped_when_every_emitter_is_willing_to_wait(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        # The tightest queue there is: every event after the first has to wait for room.
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        for index in range(10):
+            dispatcher.emit_event(flag_event(str(index)), timeout=WAIT_TIMEOUT)
+
+        assert callback.wait_for(10)
+        assert callback.feature_names == [str(index) for index in range(10)]
+        assert dispatcher.dropped_events == 0
+
+    def test_a_max_size_of_zero_means_an_unbounded_queue(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=0)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        # Nothing is draining and no emit will wait, so any bounded queue would drop.
+        for index in range(200):
+            dispatcher.emit_event(flag_event(str(index)), timeout=0)
+
+        assert dispatcher.dropped_events == 0
+
+    def test_the_drop_count_survives_close(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+        dispatcher.emit_event(flag_event("dropped"))
+        assert dispatcher.dropped_events == 1
+
+        callback.release()
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert dispatcher.dropped_events == 1
 
 
-def test_close_is_idempotent(dispatcher_factory: Callable[..., EventDispatcher]):
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
+class TestFullQueueWarning:
+    def _drop_events(
+        self, dispatcher_factory: Callable[..., EventDispatcher], count: int
+    ) -> EventDispatcher:
+        """Pins the worker, fills a one-slot queue, then drops ``count`` events on the floor."""
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
 
-    dispatcher.emit_event(flag_event())
-    dispatcher.close(timeout=WAIT_TIMEOUT)
-    dispatcher.close(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+        for index in range(count):
+            dispatcher.emit_event(flag_event(str(index)), timeout=0)
 
-    assert len(received) == 1
+        assert dispatcher.dropped_events == count
+        return dispatcher
 
+    def test_a_full_queue_is_warned_about(
+        self,
+        dispatcher_factory: Callable[..., EventDispatcher],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.WARNING, logger="UnleashClient")
 
-def test_close_returns_even_when_the_callback_hangs(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    entered = threading.Event()
-    release = threading.Event()
+        self._drop_events(dispatcher_factory, count=1)
 
-    def callback(_event: UnleashEvent):
-        entered.set()
-        _ = release.wait(timeout=WAIT_TIMEOUT)
-
-    dispatcher = dispatcher_factory(callback, max_size=1)
-
-    dispatcher.emit_event(flag_event())
-    assert entered.wait(timeout=WAIT_TIMEOUT)
-    dispatcher.emit_event(flag_event())  # fills the queue, so the sentinel can't fit
-
-    start = time.monotonic()
-    dispatcher.close(timeout=0.2)
-    elapsed = time.monotonic() - start
-
-    assert elapsed < 2
-
-    release.set()
+        assert [
+            message for message in sdk_warnings(caplog) if "queue is full" in message
+        ]
 
 
-def test_emit_event_after_close_is_a_no_op(
-    dispatcher_factory: Callable[..., EventDispatcher],
-):
-    received: list[UnleashEvent] = []
-    dispatcher = dispatcher_factory(received.append)
+class TestCallbackErrorLogging:
+    def test_a_callback_exception_is_logged_with_its_message(
+        self,
+        dispatcher_factory: Callable[..., EventDispatcher],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.WARNING, logger="UnleashClient")
+        callback = RaisingCallback(error=RuntimeError("kaboom"))
+        dispatcher = dispatcher_factory(callback)
 
-    dispatcher.emit_event(flag_event("before"))
-    dispatcher.close(timeout=WAIT_TIMEOUT)
-    dispatcher.emit_event(flag_event("after"))
-    dispatcher.emit_event(ready_event())
+        dispatcher.emit_event(flag_event())
 
-    assert [event.feature_name for event in received] == ["before"]
+        assert callback.wait_for(1)
+        dispatcher.close(
+            timeout=WAIT_TIMEOUT
+        )  # the log lands after the callback returns
+        assert any(
+            "Error in event callback" in message and "kaboom" in message
+            for message in sdk_warnings(caplog)
+        )
+
+    def test_every_failing_event_is_logged(
+        self,
+        dispatcher_factory: Callable[..., EventDispatcher],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.WARNING, logger="UnleashClient")
+        callback = RaisingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        for index in range(3):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        assert callback.wait_for(3)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        failures = [
+            message
+            for message in sdk_warnings(caplog)
+            if "Error in event callback" in message
+        ]
+        assert len(failures) == 3
+
+    def test_a_clean_run_logs_nothing(
+        self,
+        dispatcher_factory: Callable[..., EventDispatcher],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.WARNING, logger="UnleashClient")
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        for index in range(10):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        assert callback.wait_for(10)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        assert sdk_warnings(caplog) == []
+
+
+class TestClose:
+    def test_close_drains_events_that_are_still_queued(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = SlowCallback(delay=0.02)
+        dispatcher = dispatcher_factory(callback)
+
+        for index in range(10):
+            dispatcher.emit_event(flag_event(str(index)))
+
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        # No wait_for here: close() is itself the synchronization point, so everything
+        # must already have been delivered by the time it returns.
+        assert callback.feature_names == [str(index) for index in range(10)]
+
+    def test_close_is_idempotent(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event())
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        assert callback.call_count == 1
+
+    def test_a_second_close_returns_immediately(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
+        dispatcher.emit_event(flag_event())
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+
+        start = time.monotonic()
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        elapsed = time.monotonic() - start
+
+        # Already closed: there is nothing left to wait for, so no timeout is paid.
+        assert elapsed < NON_BLOCKING_BUDGET
+
+    def test_close_returns_when_the_callback_hangs(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        # The sentinel is queued but the worker is parked and will never reach it.
+        start = time.monotonic()
+        dispatcher.close(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.2 + NON_BLOCKING_BUDGET
+
+    def test_close_returns_when_the_sentinel_cannot_even_be_queued(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback, max_size=1)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+        dispatcher.emit_event(flag_event("fills the queue"))
+
+        # Now there is no room for the sentinel either, so close() cannot even ask to stop.
+        start = time.monotonic()
+        dispatcher.close(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.2 + NON_BLOCKING_BUDGET
+
+    def test_close_honors_a_zero_timeout(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = BlockingCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event("pins the worker"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
+
+        start = time.monotonic()
+        dispatcher.close(timeout=0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < NON_BLOCKING_BUDGET
+
+    def test_emit_after_close_is_a_no_op(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+
+        dispatcher.emit_event(flag_event("before"))
+        dispatcher.close(timeout=WAIT_TIMEOUT)
+        for event in (
+            flag_event("after"),
+            variant_event(),
+            ready_event(),
+            fetched_event(),
+        ):
+            dispatcher.emit_event(event)
+
+        assert not callback.wait_for(2, timeout=0.2)
+        assert callback.feature_names == ["before"]
+
+    def test_emit_after_close_starts_no_worker(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        dispatcher = dispatcher_factory(RecorderCallback())
+        dispatcher.close(timeout=0)
+        before = len(worker_threads())
+
+        dispatcher.emit_event(flag_event())
+
+        assert len(worker_threads()) == before
+
+    def test_two_threads_closing_at_once_both_return(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback = RecorderCallback()
+        dispatcher = dispatcher_factory(callback)
+        dispatcher.emit_event(flag_event())
+        returned: List[str] = []
+
+        def close_it() -> None:
+            dispatcher.close(timeout=WAIT_TIMEOUT)
+            returned.append(threading.current_thread().name)
+
+        closers = [
+            threading.Thread(target=close_it, name="closer-{}".format(index))
+            for index in range(2)
+        ]
+        for closer in closers:
+            closer.start()
+        for closer in closers:
+            closer.join(timeout=WAIT_TIMEOUT)
+
+        assert [closer.is_alive() for closer in closers] == [False, False]
+        assert sorted(returned) == ["closer-0", "closer-1"]
+        assert callback.call_count == 1

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 import time
-from typing import Callable, Iterator, List, Optional, Tuple
+from typing import Callable, Iterator, List, Tuple
 
 import pytest
 
@@ -12,7 +12,6 @@ from tests.utilities.event_callbacks import (
     ClosingCallback,
     RaisingCallback,
     RecorderCallback,
-    ReentrantCallback,
     SlowCallback,
     fetched_event,
     flag_event,
@@ -24,7 +23,6 @@ from tests.utilities.event_callbacks import (
 from UnleashClient.events import (
     BaseEvent,
     EventDispatcher,
-    UnleashEvent,
     UnleashEventType,
 )
 
@@ -618,39 +616,6 @@ class TestClose:
         # Already closed: there is nothing left to wait for, so no timeout is paid.
         assert elapsed < CLOSE_SLACK
 
-    def test_close_returns_when_the_callback_hangs(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        callback = BlockingCallback()
-        dispatcher = dispatcher_factory(callback)
-
-        dispatcher.emit_event(flag_event("pins the worker"))
-        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
-
-        # The sentinel is queued but the worker is parked and will never reach it.
-        start = time.monotonic()
-        dispatcher.close(timeout=0.2)
-        elapsed = time.monotonic() - start
-
-        assert elapsed < 0.2 + CLOSE_SLACK
-
-    def test_close_returns_when_the_sentinel_cannot_even_be_queued(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        callback = BlockingCallback()
-        dispatcher = dispatcher_factory(callback, max_size=1)
-
-        dispatcher.emit_event(flag_event("pins the worker"))
-        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
-        dispatcher.emit_event(flag_event("fills the queue"))
-
-        # Now there is no room for the sentinel either, so close() cannot even ask to stop.
-        start = time.monotonic()
-        dispatcher.close(timeout=0.2)
-        elapsed = time.monotonic() - start
-
-        assert elapsed < 0.2 + CLOSE_SLACK
-
     def test_close_honors_a_zero_timeout(
         self, dispatcher_factory: Callable[..., EventDispatcher]
     ):
@@ -708,42 +673,6 @@ class TestClose:
         dispatcher.emit_event(flag_event())
 
         assert len(worker_threads()) == before
-
-    def test_a_callback_that_emits_does_not_stall_a_concurrent_close(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        def follow_up_once(event: BaseEvent) -> Optional[BaseEvent]:
-            """One follow-up, for the first event only, so the dispatcher can't feed itself."""
-            if (
-                isinstance(event, UnleashEvent)
-                and event.feature_name == "pins the worker"
-            ):
-                return flag_event("from the callback")
-            return None
-
-        callback = ReentrantCallback(follow_up_once, gated=True)
-        dispatcher = dispatcher_factory(callback)
-        callback.bind(dispatcher)
-
-        dispatcher.emit_event(flag_event("pins the worker"))
-        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
-
-        # close() gets to run first and is already waiting on its sentinel by the time the timer
-        # lets the callback emit, which is the ordering this test is about.
-        unblock = threading.Timer(0.1, callback.release)
-        unblock.start()
-
-        start = time.monotonic()
-        dispatcher.close(timeout=CLOSE_TIMEOUT)
-        elapsed = time.monotonic() - start
-        unblock.join()
-
-        # close() came back when the callback let go, not after the whole CLOSE_TIMEOUT.
-        assert elapsed < 0.1 + CLOSE_SLACK
-        # The follow-up went into an already closed dispatcher, so it was ignored rather than
-        # holding the callback up.
-        assert callback.emitted.wait(timeout=WAIT_TIMEOUT)
-        assert callback.feature_names == ["pins the worker"]
 
     def test_closing_from_inside_the_callback_does_not_blow_up(
         self, dispatcher_factory: Callable[..., EventDispatcher]

--- a/tests/unit_tests/test_events.py
+++ b/tests/unit_tests/test_events.py
@@ -28,22 +28,28 @@ from UnleashClient.events import (
     UnleashEventType,
 )
 
-# Budget for an operation that must not wait on the callback.  Generous enough to survive a
-# loaded CI box, tight enough to fail if the emitter ever starts blocking.
-NON_BLOCKING_BUDGET = 0.5
+# close() waits on Thread.join, whose granularity is a few milliseconds.  Slack on top of the
+# timeout close() was given, so "returned when it said it would" can't be read as "waited longer".
+CLOSE_SLACK = 0.05
 
-# Timeout handed to close() when a test needs to tell "returned promptly" apart from "waited out
-# the whole timeout".  Several times NON_BLOCKING_BUDGET, so the two can't be confused.
+# Timeout handed to close() when a test needs to tell "returned as soon as the worker let go"
+# apart from "waited out the whole timeout".
 CLOSE_TIMEOUT = 2.0
+
+
+def sdk_logs(caplog: pytest.LogCaptureFixture, level: int) -> List[str]:
+    """Messages the SDK logged at ``level``, traceback included, in the order it logged them."""
+    formatter = logging.Formatter("%(message)s")
+    return [
+        formatter.format(record)
+        for record in caplog.records
+        if record.name == "UnleashClient" and record.levelno == level
+    ]
 
 
 def sdk_warnings(caplog: pytest.LogCaptureFixture) -> List[str]:
     """Messages the SDK logged at WARNING, in the order it logged them."""
-    return [
-        record.getMessage()
-        for record in caplog.records
-        if record.name == "UnleashClient" and record.levelno == logging.WARNING
-    ]
+    return sdk_logs(caplog, logging.WARNING)
 
 
 def ready_deliveries(callback: RecorderCallback) -> List[BaseEvent]:
@@ -133,29 +139,48 @@ class TestDelivery:
         callback = BlockingCallback()
         dispatcher = dispatcher_factory(callback)
 
-        dispatcher.emit_event(flag_event())
+        dispatcher.emit_event(flag_event("pins the worker"))
         assert callback.entered.wait(timeout=WAIT_TIMEOUT)
 
-        start = time.monotonic()
-        dispatcher.emit_event(flag_event())
-        elapsed = time.monotonic() - start
+        dispatcher.emit_event(flag_event("queued behind it"))
 
-        assert elapsed < NON_BLOCKING_BUDGET
+        # Control is back here, so the emit did not wait on the callback.
         assert callback.call_count == 0  # still parked inside the first event
+        assert dispatcher.dropped_events == 0  # in the queue, not on the floor
 
-    def test_a_slow_callback_never_slows_the_emitter(
+    def test_the_emitter_does_not_wait_for_the_whole_callback_duration(
         self, dispatcher_factory: Callable[..., EventDispatcher]
     ):
-        callback = SlowCallback(delay=0.05)
-        dispatcher = dispatcher_factory(callback)
+        callback: SlowCallback = SlowCallback(delay=0.05)
+        dispatcher: EventDispatcher = dispatcher_factory(callback)
 
-        start = time.monotonic()
         for _ in range(20):
             dispatcher.emit_event(flag_event())
-        elapsed = time.monotonic() - start
 
-        # A full second of callback work, none of which the emitter should have paid for.
-        assert elapsed < NON_BLOCKING_BUDGET
+        assert (
+            callback.call_count < 20
+        )  # If emitter had waited for the callback, this would be exactly 20.
+
+    def test_emitter_does_not_drop_events_despite_slow_callback(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback: SlowCallback = SlowCallback(delay=0.05)
+        dispatcher: EventDispatcher = dispatcher_factory(callback)
+
+        for _ in range(20):
+            dispatcher.emit_event(flag_event())
+
+        assert dispatcher.dropped_events == 0
+
+    def test_emitter_eventually_processes_all_events_despite_slow_callback(
+        self, dispatcher_factory: Callable[..., EventDispatcher]
+    ):
+        callback: SlowCallback = SlowCallback(delay=0.05)
+        dispatcher: EventDispatcher = dispatcher_factory(callback)
+
+        for _ in range(20):
+            dispatcher.emit_event(flag_event())
+
         assert callback.wait_for(20)
 
 
@@ -261,6 +286,8 @@ class TestBackpressure:
     Every test here pins the worker inside a BlockingCallback first.  Once ``entered`` is set the
     worker has taken its event off the queue and gone to sleep, so the queue is empty and its
     depth from then on is exactly what the test put there.
+
+    An emit never waits for room: it either finds a free slot or drops the event and counts it.
     """
 
     def test_no_events_are_dropped_before_anything_is_emitted(
@@ -309,10 +336,12 @@ class TestBackpressure:
             dispatcher.emit_event(flag_event(str(index)))
 
         callback.release()
-        dispatcher.close(timeout=WAIT_TIMEOUT)
+        assert callback.wait_for(3)
 
-        assert callback.feature_names == ["pins the worker", "0", "1"]
         assert dispatcher.dropped_events == 8
+        assert callback.feature_names == ["pins the worker", "0", "1"]
+
+        dispatcher.close(timeout=WAIT_TIMEOUT)
 
     def test_the_queue_takes_events_again_once_the_callback_drains(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -330,71 +359,12 @@ class TestBackpressure:
         callback.release()
         assert callback.wait_for(3)
 
-        # There is room again, and these emits are willing to wait for it.
-        for index in range(5):
-            dispatcher.emit_event(flag_event("after"), timeout=WAIT_TIMEOUT)
+        # The queue is empty again, so it can take another max_size events.
+        for index in range(2):
+            dispatcher.emit_event(flag_event("after"))
 
-        assert callback.wait_for(8)
+        assert callback.wait_for(5)
         assert dispatcher.dropped_events == 3
-
-    def test_emit_gives_up_after_its_own_timeout(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        callback = BlockingCallback()
-        dispatcher = dispatcher_factory(callback, max_size=1)
-
-        dispatcher.emit_event(flag_event("pins the worker"))
-        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
-        dispatcher.emit_event(flag_event("fills the queue"))
-
-        start = time.monotonic()
-        dispatcher.emit_event(flag_event("nowhere to go"), timeout=0.3)
-        elapsed = time.monotonic() - start
-
-        assert 0.3 <= elapsed < 0.3 + NON_BLOCKING_BUDGET
-        assert dispatcher.dropped_events == 1
-
-    def test_emit_waits_for_room_when_given_a_generous_timeout(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        callback = BlockingCallback()
-        dispatcher = dispatcher_factory(callback, max_size=1)
-
-        dispatcher.emit_event(flag_event("pins the worker"))
-        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
-        dispatcher.emit_event(flag_event("fills the queue"))
-
-        # The only thing that can free a slot, and it won't for another 200ms.
-        unblock = threading.Timer(0.2, callback.release)
-        unblock.start()
-
-        start = time.monotonic()
-        dispatcher.emit_event(flag_event("waits for room"), timeout=WAIT_TIMEOUT)
-        elapsed = time.monotonic() - start
-        unblock.join()
-
-        assert elapsed >= 0.1
-        assert dispatcher.dropped_events == 0
-        assert callback.wait_for(3)
-        assert callback.feature_names == [
-            "pins the worker",
-            "fills the queue",
-            "waits for room",
-        ]
-
-    def test_nothing_is_dropped_when_every_emitter_is_willing_to_wait(
-        self, dispatcher_factory: Callable[..., EventDispatcher]
-    ):
-        callback = RecorderCallback()
-        # The tightest queue there is: every event after the first has to wait for room.
-        dispatcher = dispatcher_factory(callback, max_size=1)
-
-        for index in range(10):
-            dispatcher.emit_event(flag_event(str(index)), timeout=WAIT_TIMEOUT)
-
-        assert callback.wait_for(10)
-        assert callback.feature_names == [str(index) for index in range(10)]
-        assert dispatcher.dropped_events == 0
 
     def test_a_max_size_of_zero_means_an_unbounded_queue(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -407,7 +377,7 @@ class TestBackpressure:
 
         # Nothing is draining and no emit will wait, so any bounded queue would drop.
         for index in range(200):
-            dispatcher.emit_event(flag_event(str(index)), timeout=0)
+            dispatcher.emit_event(flag_event(str(index)))
 
         assert dispatcher.dropped_events == 0
 
@@ -433,9 +403,9 @@ class TestReadyDeduplication:
     """
     The dispatcher promises READY is delivered once, however many connectors emit it.
 
-    close() is the synchronization point in these tests: the shutdown sentinel goes in at the
-    tail of a FIFO queue, so everything emitted before it has been handed to the callback by
-    the time close() returns.
+    A second READY arriving is what these tests wait for: it either shows up, and the dedup guard
+    is missing, or the wait times out because there was only ever one.  close() cannot be the
+    synchronization point any more, because it no longer drains what is still queued.
     """
 
     def test_ready_is_delivered_once_however_many_connectors_emit_it(
@@ -448,8 +418,8 @@ class TestReadyDeduplication:
         for _ in range(3):
             dispatcher.emit_event(ready_event())
 
-        dispatcher.close(timeout=WAIT_TIMEOUT)
-
+        assert callback.wait_for(1)
+        assert not callback.wait_for(2, timeout=0.2)
         assert len(ready_deliveries(callback)) == 1
 
     def test_ready_carried_on_an_unleash_event_is_deduplicated(
@@ -461,8 +431,8 @@ class TestReadyDeduplication:
         for _ in range(3):
             dispatcher.emit_event(ready_event_as_unleash_event())
 
-        dispatcher.close(timeout=WAIT_TIMEOUT)
-
+        assert callback.wait_for(1)
+        assert not callback.wait_for(2, timeout=0.2)
         assert len(ready_deliveries(callback)) == 1
 
     def test_a_ready_event_dropped_by_a_full_queue_is_still_delivered_later(
@@ -476,15 +446,15 @@ class TestReadyDeduplication:
         dispatcher.emit_event(flag_event("fills the queue"))
 
         # Nowhere to put it, so this READY never reaches the callback.
-        dispatcher.emit_event(ready_event_as_unleash_event(), timeout=0)
+        dispatcher.emit_event(ready_event_as_unleash_event())
         assert dispatcher.dropped_events == 1
 
         callback.release()
         assert callback.wait_for(2)
 
-        # The queue has drained, and this emit is willing to wait for room anyway.
-        dispatcher.emit_event(ready_event_as_unleash_event(), timeout=WAIT_TIMEOUT)
-        dispatcher.close(timeout=WAIT_TIMEOUT)
+        # The queue has drained, and this emit can be retried normally.
+        dispatcher.emit_event(ready_event_as_unleash_event())
+        assert callback.wait_for(3)
 
         assert ready_deliveries(callback), (
             "READY was dropped while the queue was full, and every later attempt was "
@@ -504,7 +474,9 @@ class TestFullQueueWarning:
         assert callback.entered.wait(timeout=WAIT_TIMEOUT)
         dispatcher.emit_event(flag_event("fills the queue"))
         for index in range(count):
-            dispatcher.emit_event(flag_event(str(index)), timeout=0)
+            dispatcher.emit_event(
+                flag_event(str(index)),
+            )
 
         assert dispatcher.dropped_events == count
         return dispatcher
@@ -544,7 +516,7 @@ class TestCallbackErrorLogging:
         dispatcher_factory: Callable[..., EventDispatcher],
         caplog: pytest.LogCaptureFixture,
     ):
-        caplog.set_level(logging.WARNING, logger="UnleashClient")
+        caplog.set_level(logging.ERROR, logger="UnleashClient")
         callback = RaisingCallback(error=RuntimeError("kaboom"))
         dispatcher = dispatcher_factory(callback)
 
@@ -556,7 +528,7 @@ class TestCallbackErrorLogging:
         )  # the log lands after the callback returns
         assert any(
             "Error in event callback" in message and "kaboom" in message
-            for message in sdk_warnings(caplog)
+            for message in sdk_logs(caplog, logging.ERROR)
         )
 
     def test_every_failing_event_is_logged(
@@ -564,7 +536,7 @@ class TestCallbackErrorLogging:
         dispatcher_factory: Callable[..., EventDispatcher],
         caplog: pytest.LogCaptureFixture,
     ):
-        caplog.set_level(logging.WARNING, logger="UnleashClient")
+        caplog.set_level(logging.ERROR, logger="UnleashClient")
         callback = RaisingCallback()
         dispatcher = dispatcher_factory(callback)
 
@@ -575,7 +547,7 @@ class TestCallbackErrorLogging:
         dispatcher.close(timeout=WAIT_TIMEOUT)
         failures = [
             message
-            for message in sdk_warnings(caplog)
+            for message in sdk_logs(caplog, logging.ERROR)
             if "Error in event callback" in message
         ]
         assert len(failures) == 3
@@ -595,23 +567,29 @@ class TestCallbackErrorLogging:
         assert callback.wait_for(10)
         dispatcher.close(timeout=WAIT_TIMEOUT)
         assert sdk_warnings(caplog) == []
+        assert sdk_logs(caplog, logging.ERROR) == []
 
 
 class TestClose:
-    def test_close_drains_events_that_are_still_queued(
+    def test_close_drops_events_that_are_still_queued(
         self, dispatcher_factory: Callable[..., EventDispatcher]
     ):
-        callback = SlowCallback(delay=0.02)
+        callback = BlockingCallback()
         dispatcher = dispatcher_factory(callback)
 
+        dispatcher.emit_event(flag_event("in flight"))
+        assert callback.entered.wait(timeout=WAIT_TIMEOUT)
         for index in range(10):
             dispatcher.emit_event(flag_event(str(index)))
 
+        # The worker is only let go once close() has run, so it finishes the event it is on and
+        # stops there rather than working through the ten behind it.
+        unblock = threading.Timer(0.1, callback.release)
+        unblock.start()
         dispatcher.close(timeout=WAIT_TIMEOUT)
+        unblock.join()
 
-        # No wait_for here: close() is itself the synchronization point, so everything
-        # must already have been delivered by the time it returns.
-        assert callback.feature_names == [str(index) for index in range(10)]
+        assert callback.feature_names == ["in flight"]
 
     def test_close_is_idempotent(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -638,7 +616,7 @@ class TestClose:
         elapsed = time.monotonic() - start
 
         # Already closed: there is nothing left to wait for, so no timeout is paid.
-        assert elapsed < NON_BLOCKING_BUDGET
+        assert elapsed < CLOSE_SLACK
 
     def test_close_returns_when_the_callback_hangs(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -654,7 +632,7 @@ class TestClose:
         dispatcher.close(timeout=0.2)
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.2 + NON_BLOCKING_BUDGET
+        assert elapsed < 0.2 + CLOSE_SLACK
 
     def test_close_returns_when_the_sentinel_cannot_even_be_queued(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -671,7 +649,7 @@ class TestClose:
         dispatcher.close(timeout=0.2)
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.2 + NON_BLOCKING_BUDGET
+        assert elapsed < 0.2 + CLOSE_SLACK
 
     def test_close_honors_a_zero_timeout(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -686,7 +664,7 @@ class TestClose:
         dispatcher.close(timeout=0)
         elapsed = time.monotonic() - start
 
-        assert elapsed < NON_BLOCKING_BUDGET
+        assert elapsed < CLOSE_SLACK
 
     def test_close_returns_promptly_when_nothing_was_ever_emitted(  # line 594
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -699,7 +677,7 @@ class TestClose:
 
         # No event was ever emitted, so no worker was ever started and there is nothing
         # for close() to wait on.
-        assert elapsed < NON_BLOCKING_BUDGET
+        assert elapsed < CLOSE_SLACK
 
     def test_emit_after_close_is_a_no_op(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -760,10 +738,12 @@ class TestClose:
         elapsed = time.monotonic() - start
         unblock.join()
 
-        assert elapsed < NON_BLOCKING_BUDGET
+        # close() came back when the callback let go, not after the whole CLOSE_TIMEOUT.
+        assert elapsed < 0.1 + CLOSE_SLACK
+        # The follow-up went into an already closed dispatcher, so it was ignored rather than
+        # holding the callback up.
         assert callback.emitted.wait(timeout=WAIT_TIMEOUT)
-        assert callback.emit_duration is not None
-        assert callback.emit_duration < NON_BLOCKING_BUDGET
+        assert callback.feature_names == ["pins the worker"]
 
     def test_closing_from_inside_the_callback_does_not_blow_up(
         self, dispatcher_factory: Callable[..., EventDispatcher]
@@ -772,13 +752,11 @@ class TestClose:
         dispatcher = dispatcher_factory(callback)
         callback.bind(dispatcher)
 
-        start = time.monotonic()
         dispatcher.emit_event(flag_event())
-        assert callback.returned.wait(timeout=WAIT_TIMEOUT)
-        elapsed = time.monotonic() - start
 
+        # The worker closing the dispatcher would be joining itself, which raises.
+        assert callback.returned.wait(timeout=WAIT_TIMEOUT)
         assert callback.error is None
-        assert elapsed < NON_BLOCKING_BUDGET
 
     def test_two_threads_closing_at_once_both_return(
         self, dispatcher_factory: Callable[..., EventDispatcher]

--- a/tests/utilities/event_callbacks.py
+++ b/tests/utilities/event_callbacks.py
@@ -1,0 +1,241 @@
+"""
+Callables and event builders for the EventDispatcher tests.
+
+Every callback here records what it received, so a test can assert on delivery whichever
+behavior it picked.  ``RecorderCallback.wait_for`` is how tests wait for the worker thread
+"""
+
+import threading
+import time
+import uuid
+from typing import Callable, List, Optional
+
+from UnleashClient.events import (
+    BaseEvent,
+    EventDispatcher,
+    UnleashEvent,
+    UnleashEventType,
+    UnleashFetchedEvent,
+    UnleashReadyEvent,
+)
+
+WAIT_TIMEOUT = 5
+DISPATCHER_THREAD_NAME = "UnleashEventDispatcher"
+
+
+class RecorderCallback:
+    """
+    Records every event it is handed, along with the thread it ran on.
+    """
+
+    def __init__(self) -> None:
+        self._arrivals = threading.Condition()
+        self._events: List[BaseEvent] = []
+        self._threads: List[str] = []
+
+    def __call__(self, event: BaseEvent) -> None:
+        self.record(event)
+
+    def record(self, event: BaseEvent) -> None:
+        """Subclasses call this instead of ``super().__call__`` when they add behavior."""
+        with self._arrivals:
+            self._events.append(event)
+            self._threads.append(threading.current_thread().name)
+            self._arrivals.notify_all()
+
+    @property
+    def events(self) -> List[BaseEvent]:
+        with self._arrivals:
+            return list(self._events)
+
+    @property
+    def threads(self) -> List[str]:
+        """Names of the threads the callback ran on, in arrival order."""
+        with self._arrivals:
+            return list(self._threads)
+
+    @property
+    def feature_names(self) -> List[str]:
+        """Feature names in arrival order.  Events without one are skipped."""
+        return [
+            event.feature_name
+            for event in self.events
+            if isinstance(event, UnleashEvent)
+        ]
+
+    @property
+    def call_count(self) -> int:
+        with self._arrivals:
+            return len(self._events)
+
+    def wait_for(self, count: int, timeout: float = WAIT_TIMEOUT) -> bool:
+        """Blocks until ``count`` events have arrived.  Returns False if they never do."""
+        with self._arrivals:
+            return self._arrivals.wait_for(
+                lambda: len(self._events) >= count, timeout=timeout
+            )
+
+
+class RaisingCallback(RecorderCallback):
+    """
+    Records the event, then raises.  ``times`` caps how many of the first events blow up;
+    by default every one does.
+    """
+
+    def __init__(
+        self, error: Optional[Exception] = None, times: Optional[int] = None
+    ) -> None:
+        super().__init__()
+        self.error = error if error is not None else RuntimeError("callback exploded")
+        self._times = times
+
+    def __call__(self, event: BaseEvent) -> None:
+        self.record(event)
+        if self._times is None or self.call_count <= self._times:
+            raise self.error
+
+
+class BlockingCallback(RecorderCallback):
+    """
+    Parks the worker inside the callback until ``release()``, then records.
+
+    ``entered`` is set as soon as the worker reaches the callback, which is how a test knows the
+    worker is pinned and the queue can be filled to a known depth.  Release is sticky: once
+    released, later events pass straight through.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = threading.Event()
+        self._released = threading.Event()
+
+    def __call__(self, event: BaseEvent) -> None:
+        self.entered.set()
+        _ = self._released.wait(timeout=WAIT_TIMEOUT)
+        self.record(event)
+
+    def release(self) -> None:
+        self._released.set()
+
+
+class SlowCallback(RecorderCallback):
+    """Spends ``delay`` seconds on every event."""
+
+    def __init__(self, delay: float) -> None:
+        super().__init__()
+        self._delay = delay
+
+    def __call__(self, event: BaseEvent) -> None:
+        time.sleep(self._delay)
+        self.record(event)
+
+
+class ReentrantCallback(RecorderCallback):
+    """
+    Emits a follow-up event back into the dispatcher from inside the callback.
+
+    ``build_event`` returns the follow-up, or None to stop.  Without a stopping condition the
+    dispatcher would feed itself forever.
+    """
+
+    def __init__(self, build_event: Callable[[BaseEvent], Optional[BaseEvent]]) -> None:
+        super().__init__()
+        self._build_event = build_event
+        self._dispatcher: Optional[EventDispatcher] = None
+
+    def bind(self, dispatcher: EventDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    def __call__(self, event: BaseEvent) -> None:
+        self.record(event)
+        follow_up = self._build_event(event)
+        if follow_up is not None and self._dispatcher is not None:
+            self._dispatcher.emit_event(follow_up)
+
+
+class ClosingCallback(RecorderCallback):
+    """
+    Closes the dispatcher from inside the callback, i.e. from the worker thread itself.
+
+    ``returned`` is set once close() is done, and ``error`` holds whatever it raised.
+    """
+
+    def __init__(self, timeout: float = 0.2) -> None:
+        super().__init__()
+        self._timeout = timeout
+        self._dispatcher: Optional[EventDispatcher] = None
+        self.returned = threading.Event()
+        self.error: Optional[BaseException] = None
+
+    def bind(self, dispatcher: EventDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    def __call__(self, event: BaseEvent) -> None:
+        self.record(event)
+        try:
+            if self._dispatcher is not None:
+                self._dispatcher.close(timeout=self._timeout)
+        except BaseException as exc:
+            self.error = exc
+            raise
+        finally:
+            self.returned.set()
+
+
+def flag_event(feature_name: str = "testFlag", enabled: bool = True) -> UnleashEvent:
+    return UnleashEvent(
+        event_type=UnleashEventType.FEATURE_FLAG,
+        event_id=uuid.uuid4(),
+        context={},
+        enabled=enabled,
+        feature_name=feature_name,
+    )
+
+
+def variant_event(
+    feature_name: str = "testFlag", variant: str = "testVariant"
+) -> UnleashEvent:
+    return UnleashEvent(
+        event_type=UnleashEventType.VARIANT,
+        event_id=uuid.uuid4(),
+        context={},
+        enabled=True,
+        feature_name=feature_name,
+        variant=variant,
+    )
+
+
+def ready_event() -> UnleashReadyEvent:
+    """The READY event the client actually emits."""
+    return UnleashReadyEvent(
+        event_type=UnleashEventType.READY,
+        event_id=uuid.uuid4(),
+    )
+
+
+def ready_event_as_unleash_event() -> UnleashEvent:
+    """READY carried on an UnleashEvent, the shape the dispatcher's dedupe guard matches."""
+    return UnleashEvent(
+        event_type=UnleashEventType.READY,
+        event_id=uuid.uuid4(),
+        context={},
+        enabled=True,
+        feature_name="",
+    )
+
+
+def fetched_event(raw_features: str = '{"features": []}') -> UnleashFetchedEvent:
+    return UnleashFetchedEvent(
+        event_type=UnleashEventType.FETCHED,
+        event_id=uuid.uuid4(),
+        raw_features=raw_features,
+    )
+
+
+def worker_threads() -> List[threading.Thread]:
+    """Live dispatcher workers, found by the name the dispatcher gives its thread."""
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread.name == DISPATCHER_THREAD_NAME
+    ]

--- a/tests/utilities/event_callbacks.py
+++ b/tests/utilities/event_callbacks.py
@@ -136,21 +136,45 @@ class ReentrantCallback(RecorderCallback):
 
     ``build_event`` returns the follow-up, or None to stop.  Without a stopping condition the
     dispatcher would feed itself forever.
+
+    With ``gated``, the follow-up is held back until ``release()``, which lets a test line the
+    re-entrant emit up against work happening on another thread.  ``entered`` is set as soon as
+    the worker reaches the callback; ``emitted`` and ``emit_duration`` report on the follow-up
+    emit once it returns.
     """
 
-    def __init__(self, build_event: Callable[[BaseEvent], Optional[BaseEvent]]) -> None:
+    def __init__(
+        self,
+        build_event: Callable[[BaseEvent], Optional[BaseEvent]],
+        gated: bool = False,
+    ) -> None:
         super().__init__()
         self._build_event = build_event
         self._dispatcher: Optional[EventDispatcher] = None
+        self.entered = threading.Event()
+        self.emitted = threading.Event()
+        self.emit_duration: Optional[float] = None
+        self._released = threading.Event()
+        if not gated:
+            self._released.set()
 
     def bind(self, dispatcher: EventDispatcher) -> None:
         self._dispatcher = dispatcher
 
+    def release(self) -> None:
+        self._released.set()
+
     def __call__(self, event: BaseEvent) -> None:
         self.record(event)
+        self.entered.set()
+        _ = self._released.wait(timeout=WAIT_TIMEOUT)
+
         follow_up = self._build_event(event)
         if follow_up is not None and self._dispatcher is not None:
+            start = time.monotonic()
             self._dispatcher.emit_event(follow_up)
+            self.emit_duration = time.monotonic() - start
+            self.emitted.set()
 
 
 class ClosingCallback(RecorderCallback):

--- a/tests/utilities/event_callbacks.py
+++ b/tests/utilities/event_callbacks.py
@@ -139,8 +139,7 @@ class ReentrantCallback(RecorderCallback):
 
     With ``gated``, the follow-up is held back until ``release()``, which lets a test line the
     re-entrant emit up against work happening on another thread.  ``entered`` is set as soon as
-    the worker reaches the callback; ``emitted`` and ``emit_duration`` report on the follow-up
-    emit once it returns.
+    the worker reaches the callback; ``emitted`` is set once the follow-up emit returns.
     """
 
     def __init__(
@@ -153,7 +152,6 @@ class ReentrantCallback(RecorderCallback):
         self._dispatcher: Optional[EventDispatcher] = None
         self.entered = threading.Event()
         self.emitted = threading.Event()
-        self.emit_duration: Optional[float] = None
         self._released = threading.Event()
         if not gated:
             self._released.set()
@@ -171,9 +169,7 @@ class ReentrantCallback(RecorderCallback):
 
         follow_up = self._build_event(event)
         if follow_up is not None and self._dispatcher is not None:
-            start = time.monotonic()
             self._dispatcher.emit_event(follow_up)
-            self.emit_duration = time.monotonic() - start
             self.emitted.set()
 
 


### PR DESCRIPTION
## Summary

The pull request introduces the implementation of `EventDispatcher`. Its goal is to move all event-and-callback-related code to the same file. At the same time, the `EventDispatcher` is based on threads: the "callers" of the dispatcher will use `emit_event` to queue an event, and a worker thread managed by the dispatcher will drain the queue.

In this pull request, the Dispatcher is not yet wired to anyone.

## Reason for these changes

This is the initial step towards solving two problems:
1. the user-provided event callback currently runs in the hot path, making it possible for users to stall `is_enabled` indefinitely; and
2. the async counterpart to the current `UnleashClient` (i.e. `AsyncUnleashClient`) will also support sending events to a callback

By introducing a single class that deals with event-sending as a whole, code will be shared and we ensure we don't run it in the hot path anymore (as long as we publish events through the `EventDispatcher`).

## Tricky parts when reviewing

### Threads and locks

`EventDispatcher` deals with locks and threads, which is always fun. Variables like `_closed`, as well as the two centinels ( `_SHUTDOWN` and `_FlushMarker`) help manage the synchronization of operations:

- To avoid race conditions
- To avoid leaving the Dispatcher in an inconsistent state (e.g. allowing to send after having invoked `close()`

### Backpressure

I discarded the option of adding a timeout or a number of retries to a user's callback. I'm happy to revisit the decision.

