### PR TITLE
Replace callbacks with event dispatcher in UnleashClient and its Connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+* (Minor): Event callbacks are now invoked on a dedicated background thread instead of on whichever thread produced the event. `is_enabled()` and `get_variant()` no longer wait for your callback, so a slow callback can't hold up flag evaluation. Three consequences worth knowing about: callbacks can no longer read thread local state from the caller (Flask `g`, the current Django request, contextvars); they return before the callback has run, so tests asserting straight after the call now need to wait; and reassigning `unleash_event_callback` after construction is no longer honoured.
+* (Minor): Connectors take an `EventDispatcher` instead of `ready_callback`/`event_callback`. These classes aren't part of the documented API, so this only affects code importing from `UnleashClient.connectors` directly.
+
 ## v6.7.0
 * (Minor): Support for CIDR, Semver GTE and LTE constraints
 

--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -38,6 +38,7 @@ from UnleashClient.constants import (
 )
 from UnleashClient.events import (
     BaseEvent,
+    EventDispatcher,
     UnleashEvent,
     UnleashEventType,
     UnleashReadyEvent,
@@ -85,6 +86,11 @@ def build_ready_callback(
 ) -> Optional[Callable]:
     """
     Builds a callback function that can be used to notify when the Unleash client is ready.
+
+    .. deprecated::
+        READY is now emitted through :class:`UnleashClient.events.EventDispatcher`,
+        which deduplicates it itself.  This helper is retained for backwards
+        compatibility and is no longer used internally.
     """
 
     if not event_callback:
@@ -137,7 +143,7 @@ class UnleashClient:
     :param scheduler: Custom APScheduler object.  Use this if you want to customize jobstore or executors.  When unset, UnleashClient will create it's own scheduler.
     :param scheduler_executor: Name of APSCheduler executor to use if using a custom scheduler.
     :param multiple_instance_mode: Determines how multiple instances being instantiated is handled by the SDK, when set to InstanceAllowType.BLOCK, the client constructor will fail when more than one instance is detected, when set to InstanceAllowType.WARN, multiple instances will be allowed but log a warning, when set to InstanceAllowType.SILENTLY_ALLOW, no warning or failure will be raised when instantiating multiple instances of the client. Defaults to InstanceAllowType.WARN
-    :param event_callback: Function to call if impression events are enabled.  WARNING: Depending on your event library, this may have performance implications!
+    :param event_callback: Function to call if impression events are enabled.  Called on a dedicated background thread, so it must not rely on thread local state from the caller.
     :param experimental_mode: Optional dict to configure mode. Use {"type": "streaming"} to enable streaming or {"type": "polling"} (default).
     :param sdk_flavor: Optional identifier of an integration built on top of this SDK (e.g. an OpenFeature provider). Sent in the register + metrics payloads alongside sdkVersion so adoption of the integration can be tracked. Leave unset for plain SDK usage.
     :param sdk_flavor_version: Optional version of the integration named by sdk_flavor.
@@ -205,7 +211,11 @@ class UnleashClient:
         self.unleash_project_name = project_name
         self.unleash_verbose_log_level = verbose_log_level
         self.unleash_event_callback = event_callback
-        self._ready_callback = build_ready_callback(event_callback)
+        # Events are handed to the dispatcher, which delivers them to the user's
+        # callback on its own thread.  The callback is never called from here.
+        self.__events: Optional[EventDispatcher] = (
+            EventDispatcher(event_callback) if event_callback is not None else None
+        )
         self.connector_mode: ExperimentalMode = experimental_mode or {"type": "polling"}
         self._lifecycle_lock = threading.RLock()
         self._closed = threading.Event()
@@ -361,7 +371,7 @@ class UnleashClient:
                         url=self.unleash_url,
                         headers=base_headers,
                         request_timeout=self.unleash_request_timeout,
-                        ready_callback=self._ready_callback,
+                        events=self.__events,
                         custom_options=self.unleash_custom_options,
                     )
                 elif fetch_toggles:
@@ -380,8 +390,7 @@ class UnleashClient:
                         project=self.unleash_project_name,
                         scheduler_executor=self.unleash_executor_name,
                         refresh_interval=self.unleash_refresh_interval,
-                        event_callback=self.unleash_event_callback,
-                        ready_callback=self._ready_callback,
+                        events=self.__events,
                     )
                 else:
                     start_scheduler = True
@@ -392,7 +401,7 @@ class UnleashClient:
                         scheduler_executor=self.unleash_executor_name,
                         refresh_interval=self.unleash_refresh_interval,
                         refresh_jitter=self.unleash_refresh_jitter,
-                        ready_callback=self._ready_callback,
+                        events=self.__events,
                     )
 
                 self.connector.start()
@@ -513,6 +522,11 @@ class UnleashClient:
                 except Exception as exc:
                     LOGGER.warning("Exception during cache teardown: %s", exc)
 
+            # Closed last: the scheduler has to drain first, otherwise an
+            # in-flight poll can still queue events we'd silently drop.
+            if self.__events:
+                self.__events.close()
+
     @staticmethod
     def _redact_to_print_safely(value: Optional[str]) -> Optional[str]:
         if not value:
@@ -561,23 +575,20 @@ class UnleashClient:
 
         self.engine.count_toggle(feature_name, feature_enabled)
         try:
-            if (
-                self.unleash_event_callback
-                and self.engine.should_emit_impression_event(feature_name)
-            ):
-                event = UnleashEvent(
-                    event_type=UnleashEventType.FEATURE_FLAG,
-                    event_id=uuid.uuid4(),
-                    context=context,
-                    enabled=feature_enabled,
-                    feature_name=feature_name,
+            if self.__events and self.engine.should_emit_impression_event(feature_name):
+                self.__events.emit_event(
+                    UnleashEvent(
+                        event_type=UnleashEventType.FEATURE_FLAG,
+                        event_id=uuid.uuid4(),
+                        context=context,
+                        enabled=feature_enabled,
+                        feature_name=feature_name,
+                    )
                 )
-
-                self.unleash_event_callback(event)
         except Exception as excep:
             LOGGER.log(
                 self.unleash_verbose_log_level,
-                "Error in event callback: %s",
+                "Error emitting impression event: %s",
                 excep,
             )
 
@@ -611,26 +622,24 @@ class UnleashClient:
         self.engine.count_variant(feature_name, variant["name"])
         self.engine.count_toggle(feature_name, variant["feature_enabled"])
 
-        if self.unleash_event_callback and self.engine.should_emit_impression_event(
-            feature_name
-        ):
-            try:
-                event = UnleashEvent(
-                    event_type=UnleashEventType.VARIANT,
-                    event_id=uuid.uuid4(),
-                    context=context,
-                    enabled=bool(variant["enabled"]),
-                    feature_name=feature_name,
-                    variant=str(variant["name"]),
+        try:
+            if self.__events and self.engine.should_emit_impression_event(feature_name):
+                self.__events.emit_event(
+                    UnleashEvent(
+                        event_type=UnleashEventType.VARIANT,
+                        event_id=uuid.uuid4(),
+                        context=context,
+                        enabled=bool(variant["enabled"]),
+                        feature_name=feature_name,
+                        variant=str(variant["name"]),
+                    )
                 )
-
-                self.unleash_event_callback(event)
-            except Exception as excep:
-                LOGGER.log(
-                    self.unleash_verbose_log_level,
-                    "Error in event callback: %s",
-                    excep,
-                )
+        except Exception as excep:
+            LOGGER.log(
+                self.unleash_verbose_log_level,
+                "Error emitting impression event: %s",
+                excep,
+            )
 
         return variant
 

--- a/UnleashClient/connectors/base_connector.py
+++ b/UnleashClient/connectors/base_connector.py
@@ -1,10 +1,17 @@
+import uuid
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Optional
 
 from yggdrasil_engine.engine import UnleashEngine
 
 from UnleashClient.cache import BaseCache
 from UnleashClient.constants import FEATURES_URL
+from UnleashClient.events import (
+    BaseEvent,
+    EventDispatcher,
+    UnleashEventType,
+    UnleashReadyEvent,
+)
 from UnleashClient.utils import LOGGER
 
 
@@ -13,16 +20,16 @@ class BaseConnector(ABC):
         self,
         engine: UnleashEngine,
         cache: BaseCache,
-        ready_callback: Optional[Callable] = None,
+        events: Optional[EventDispatcher] = None,
     ):
         """
         :param engine: Feature evaluation engine instance (UnleashEngine).
         :param cache: Should be the cache class variable from UnleashClient
-        :param ready_callback: Optional function to call when features are successfully loaded.
+        :param events: Optional dispatcher that delivers events to the user's callback.
         """
         self.engine = engine
         self.cache = cache
-        self.ready_callback = ready_callback
+        self._events = events
 
     @abstractmethod
     def start(self):
@@ -31,6 +38,32 @@ class BaseConnector(ABC):
     @abstractmethod
     def stop(self):
         pass
+
+    def emit(self, event: BaseEvent) -> None:
+        """
+        Hands an event to the dispatcher, if the user asked for events at all.
+        Emitting never raises: connectors shouldn't have to guard their own
+        control flow against a failing event.
+        """
+        if not self._events:
+            return
+
+        try:
+            self._events.emit_event(event)
+        except Exception:
+            LOGGER.debug("Failed to emit %s event", event.event_type, exc_info=True)
+
+    def emit_ready(self) -> None:
+        """
+        The dispatcher only ever delivers READY once, so connectors are free to
+        call this as often as they like.
+        """
+        self.emit(
+            UnleashReadyEvent(
+                event_type=UnleashEventType.READY,
+                event_id=uuid.uuid4(),
+            )
+        )
 
     def load_features(self):
         feature_provisioning = self.cache.get(FEATURES_URL)
@@ -43,8 +76,7 @@ class BaseConnector(ABC):
 
         try:
             warnings = self.engine.take_state(feature_provisioning)
-            if self.ready_callback:
-                self.ready_callback()
+            self.emit_ready()
             if warnings:
                 LOGGER.warning(
                     "Some features were not able to be parsed correctly, they may not evaluate as expected"

--- a/UnleashClient/connectors/bootstrap_connector.py
+++ b/UnleashClient/connectors/bootstrap_connector.py
@@ -12,10 +12,14 @@ class BootstrapConnector(BaseConnector):
         cache: BaseCache,
     ):
         super().__init__(engine, cache)
-        self.engine = engine
-        self.cache = cache
         self.job = None
 
+    # TODO: this connector is never given an EventDispatcher, so bootstrapping
+    # does not emit a READY event. Bootstrapped clients only see READY once
+    # initialize_client() builds a polling, streaming or offline connector.
+    #
+    # This call to start() might need to be moved from ``UnleashClient``'s
+    # constructor to ``initialize_client``.
     def start(self):
         self.load_features()
 

--- a/UnleashClient/connectors/offline_connector.py
+++ b/UnleashClient/connectors/offline_connector.py
@@ -1,10 +1,11 @@
-from typing import Callable
+from typing import Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from yggdrasil_engine.engine import UnleashEngine
 
 from UnleashClient.cache import BaseCache
+from UnleashClient.events import EventDispatcher
 
 from .base_connector import BaseConnector
 
@@ -18,11 +19,9 @@ class OfflineConnector(BaseConnector):
         scheduler_executor: str = "default",
         refresh_interval: int = 15,
         refresh_jitter: int = None,
-        ready_callback: Callable = None,
+        events: Optional[EventDispatcher] = None,
     ):
-        self.engine = engine
-        self.cache = cache
-        self.ready_callback = ready_callback
+        super().__init__(engine, cache, events)
         self.scheduler = scheduler
         self.scheduler_executor = scheduler_executor
         self.refresh_interval = refresh_interval
@@ -40,8 +39,7 @@ class OfflineConnector(BaseConnector):
             executor=self.scheduler_executor,
         )
 
-        if self.ready_callback:
-            self.ready_callback()
+        self.emit_ready()
 
     def stop(self):
         if self.job:

--- a/UnleashClient/connectors/polling_connector.py
+++ b/UnleashClient/connectors/polling_connector.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Callable, Optional
+from typing import Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -8,7 +8,7 @@ from yggdrasil_engine.engine import UnleashEngine
 from UnleashClient.api import get_feature_toggles
 from UnleashClient.cache import BaseCache
 from UnleashClient.constants import ETAG, FEATURES_URL
-from UnleashClient.events import UnleashEventType, UnleashFetchedEvent
+from UnleashClient.events import EventDispatcher, UnleashEventType, UnleashFetchedEvent
 from UnleashClient.utils import LOGGER
 
 from .base_connector import BaseConnector
@@ -31,11 +31,9 @@ class PollingConnector(BaseConnector):
         scheduler_executor: str = "default",
         refresh_interval: int = 15,
         refresh_jitter: int = None,
-        event_callback: Optional[Callable] = None,
-        ready_callback: Optional[Callable] = None,
+        events: Optional[EventDispatcher] = None,
     ):
-        self.engine = engine
-        self.cache = cache
+        super().__init__(engine, cache, events)
         self.scheduler = scheduler
         self.url = url
         self.app_name = app_name
@@ -48,8 +46,6 @@ class PollingConnector(BaseConnector):
         self.scheduler_executor = scheduler_executor
         self.refresh_interval = refresh_interval
         self.refresh_jitter = refresh_jitter
-        self.event_callback = event_callback
-        self.ready_callback = ready_callback
         self.job = None
 
     def _fetch_and_load(self):
@@ -81,15 +77,14 @@ class PollingConnector(BaseConnector):
         self.load_features()
 
         if state:
-            if self.event_callback:
-                event = UnleashFetchedEvent(
+            self.emit(
+                UnleashFetchedEvent(
                     event_type=UnleashEventType.FETCHED,
                     event_id=uuid.uuid4(),
                     raw_features=state,
                 )
-                self.event_callback(event)
-            if self.ready_callback:
-                self.ready_callback()
+            )
+            self.emit_ready()
 
     def start(self):
         self._fetch_and_load()

--- a/UnleashClient/connectors/streaming_connector.py
+++ b/UnleashClient/connectors/streaming_connector.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Callable, Optional
+from typing import Optional
 
 from ld_eventsource import SSEClient
 from ld_eventsource.config import ConnectStrategy, ErrorStrategy, RetryDelayStrategy
@@ -8,6 +8,7 @@ from yggdrasil_engine.engine import UnleashEngine
 from UnleashClient.cache import BaseCache
 from UnleashClient.connectors.base_connector import BaseConnector
 from UnleashClient.constants import APPLICATION_HEADERS, FEATURES_URL, STREAMING_URL
+from UnleashClient.events import EventDispatcher
 from UnleashClient.utils import LOGGER
 
 
@@ -19,14 +20,14 @@ class StreamingConnector(BaseConnector):
         url: str,
         headers: dict,
         request_timeout: int,
-        ready_callback: Optional[Callable] = None,
+        events: Optional[EventDispatcher] = None,
         backoff_initial: float = 2.0,
         backoff_max: float = 30.0,
         backoff_multiplier: float = 2.0,
         backoff_jitter: Optional[float] = 0.5,
         custom_options: Optional[dict] = None,
     ) -> None:
-        super().__init__(engine=engine, cache=cache, ready_callback=ready_callback)
+        super().__init__(engine=engine, cache=cache, events=events)
         self._base_url = url.rstrip("/") + STREAMING_URL
         self._headers = {
             **headers,
@@ -102,11 +103,8 @@ class StreamingConnector(BaseConnector):
                         self.engine.take_state(event.data)
                         self.cache.set(FEATURES_URL, self.engine.get_state())
 
-                        if event.event == "unleash-connected" and self.ready_callback:
-                            try:
-                                self.ready_callback()
-                            except Exception:
-                                LOGGER.debug("Ready callback failed", exc_info=True)
+                        if event.event == "unleash-connected":
+                            self.emit_ready()
                     except Exception:
                         LOGGER.error("Error applying streaming state", exc_info=True)
                         self.load_features()

--- a/docs/eventcallbacks.rst
+++ b/docs/eventcallbacks.rst
@@ -47,7 +47,7 @@ the thread that called ``is_enabled()`` or ``get_variant()``. This means:
 * **Thread local state from the caller isn't available.** Flask's ``g``, the
   current Django request, ``contextvars`` and similar will not be set. Read
   anything you need from the event itself, or capture it before the call.
-* **Callbacks are serialised.** Events are delivered one at a time, in order, so
+* **Callbacks run sequentially.** Events are delivered one at a time, in order, so
   your callback doesn't need to be thread safe against itself.
 * **Events are dropped if you can't keep up.** Up to 10,000 events are held while
   waiting on your callback; beyond that, events are discarded and a warning is

--- a/docs/eventcallbacks.rst
+++ b/docs/eventcallbacks.rst
@@ -33,3 +33,24 @@ Example code using `blinker <https://github.com/pallets-eco/blinker>`_:
     )
     client.initialize_client()
     client.is_enabled("testFlag")
+
+Threading
+=========
+
+Your callback runs on a single background thread owned by the client, never on
+the thread that called ``is_enabled()`` or ``get_variant()``. This means:
+
+* **Calls don't block on your callback.** ``is_enabled()`` returns as soon as the
+  event is queued, so a slow callback can't slow down flag evaluation. It also
+  means the call returns *before* your callback has run - if you need to assert on
+  an event in a test, wait for it rather than checking immediately afterwards.
+* **Thread local state from the caller isn't available.** Flask's ``g``, the
+  current Django request, ``contextvars`` and similar will not be set. Read
+  anything you need from the event itself, or capture it before the call.
+* **Callbacks are serialised.** Events are delivered one at a time, in order, so
+  your callback doesn't need to be thread safe against itself.
+* **Events are dropped if you can't keep up.** Up to 10,000 events are held while
+  waiting on your callback; beyond that, events are discarded and a warning is
+  logged. Exceptions raised by your callback are logged and otherwise ignored.
+* **Call** ``destroy()`` **when you're done.** It delivers whatever is still
+  queued before shutting the thread down.

--- a/docs/eventcallbacks.rst
+++ b/docs/eventcallbacks.rst
@@ -49,7 +49,7 @@ the thread that called ``is_enabled()`` or ``get_variant()``. This means:
   anything you need from the event itself, or capture it before the call.
 * **Callbacks run sequentially.** Events are delivered one at a time, in order, so
   your callback doesn't need to be thread safe against itself.
-* **Events are dropped if you can't keep up.** Up to 10,000 events are held while
+* **Events are dropped if you can't keep up.** Up to 100 events are held while
   waiting on your callback; beyond that, events are discarded and a warning is
   logged. Exceptions raised by your callback are logged and otherwise ignored.
 * **Call** ``destroy()`` **when you're done.** It delivers whatever is still

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,28 @@ from datetime import datetime, timezone
 
 import pytest
 
+from tests.utilities.events import EventRecorder
 from tests.utilities.mocks import MOCK_ALL_FEATURES, MOCK_CUSTOM_STRATEGY
 from tests.utilities.mocks.mock_features import MOCK_FEATURES_WITH_SEGMENTS_RESPONSE
 from UnleashClient.cache import FileCache
 from UnleashClient.constants import ETAG, FEATURES_URL, METRIC_LAST_SENT_TIME
+from UnleashClient.events import EventDispatcher
+
+
+@pytest.fixture()
+def recorder():
+    return EventRecorder()
+
+
+@pytest.fixture()
+def dispatcher(recorder):
+    """
+    A dispatcher wired to the `recorder` fixture, closed on teardown so a wedged
+    worker can't leak into the next test.
+    """
+    event_dispatcher = EventDispatcher(recorder)
+    yield event_dispatcher
+    event_dispatcher.close(timeout=1)
 
 
 @pytest.fixture()

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -1585,26 +1585,6 @@ def test_is_enabled_does_not_block_on_a_slow_callback():
     unleash_client.destroy()
 
 
-def test_destroy_loses_queued_events():
-    release = threading.Event()
-    recorder = EventRecorder()
-
-    def gated_callback(event):
-        release.wait(timeout=WAIT_TIMEOUT)
-        recorder(event)
-
-    unleash_client = bootstrapped_client(gated_callback)
-    unleash_client.initialize_client(fetch_toggles=False)
-
-    for _ in range(5):
-        unleash_client.is_enabled("testFlag")
-
-    release.set()
-    unleash_client.destroy()
-
-    assert len(recorder.of_type(UnleashEventType.FEATURE_FLAG)) == 0
-
-
 def test_callback_exception_does_not_break_is_enabled_or_get_variant():
     recorder = EventRecorder()
     first_call = True

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -11,8 +11,8 @@ import pytest
 import responses
 from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.schedulers.background import BackgroundScheduler
-from blinker import Signal, signal
 
+from tests.utilities.events import WAIT_TIMEOUT, EventRecorder, wait_until
 from tests.utilities.mocks.mock_all_features import MOCK_ALL_FEATURES
 from tests.utilities.mocks.mock_features import (
     MOCK_FEATURE_ENABLED_NO_VARIANTS_RESPONSE,
@@ -45,7 +45,7 @@ from tests.utilities.testing_constants import (
 from UnleashClient import INSTANCES, UnleashClient
 from UnleashClient.cache import BaseCache, FileCache
 from UnleashClient.constants import FEATURES_URL, METRICS_URL, REGISTER_URL
-from UnleashClient.events import BaseEvent, UnleashEvent, UnleashEventType
+from UnleashClient.events import UnleashEventType
 from UnleashClient.utils import InstanceAllowType
 
 
@@ -69,21 +69,8 @@ class EnvironmentStrategy:
 
 
 def build_event_handlers():
-    send_data = Signal()
-    ready_signal = threading.Event()
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def handle_event(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            fetch_signal.set()
-
-    def event_handler(event: BaseEvent):
-        send_data.send("anonymous", data=event)
-
-    return event_handler, ready_signal, fetch_signal
+    recorder = EventRecorder()
+    return recorder, recorder.ready, recorder.fetched
 
 
 @pytest.fixture(autouse=True)
@@ -99,19 +86,7 @@ def cache(tmpdir):
 
 @pytest.fixture()
 def readyable_unleash_client(cache):
-    send_data = Signal()
-    ready_signal = threading.Event()
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def handle_event(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            fetch_signal.set()
-
-    def event_handler(event: BaseEvent):
-        send_data.send("anonymous", data=event)
+    event_handler, ready_signal, fetch_signal = build_event_handlers()
 
     unleash_client = UnleashClient(
         URL,
@@ -127,19 +102,7 @@ def readyable_unleash_client(cache):
 
 @pytest.fixture()
 def readyable_unleash_client_project(cache):
-    send_data = Signal()
-    ready_signal = threading.Event()
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def handle_event(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            fetch_signal.set()
-
-    def event_handler(event: BaseEvent):
-        send_data.send("anonymous", data=event)
+    event_handler, ready_signal, fetch_signal = build_event_handlers()
 
     unleash_client = UnleashClient(
         URL,
@@ -156,19 +119,7 @@ def readyable_unleash_client_project(cache):
 
 @pytest.fixture()
 def readyable_unleash_client_nodestroy(cache):
-    send_data = Signal()
-    ready_signal = threading.Event()
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def handle_event(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            fetch_signal.set()
-
-    def event_handler(event: BaseEvent):
-        send_data.send("anonymous", data=event)
+    event_handler, ready_signal, fetch_signal = build_event_handlers()
 
     unleash_client = UnleashClient(
         URL,
@@ -183,19 +134,7 @@ def readyable_unleash_client_nodestroy(cache):
 
 @pytest.fixture()
 def readyable_unleash_client_toggle_only(cache):
-    send_data = Signal()
-    ready_signal = threading.Event()
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def handle_event(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            fetch_signal.set()
-
-    def event_handler(event: BaseEvent):
-        send_data.send("anonymous", data=event)
+    event_handler, ready_signal, fetch_signal = build_event_handlers()
 
     unleash_client = UnleashClient(
         URL,
@@ -288,7 +227,7 @@ def test_uc_lifecycle(readyable_unleash_client):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_initialized
     assert len(unleash_client.feature_definitions()) >= 4
 
@@ -309,9 +248,13 @@ def test_uc_lifecycle(readyable_unleash_client):
         status=200,
         headers={"etag": "W/somethingelse"},
     )
+    # Waiting on fetch_signal would race: a FETCHED queued before the clear can
+    # be delivered after it.  Wait on the provisioning itself instead.
     fetch_signal.clear()
-    fetch_signal.wait(timeout=REFRESH_INTERVAL * 3)
-    assert len(unleash_client.feature_definitions()) >= 9
+    assert wait_until(
+        lambda: len(unleash_client.feature_definitions()) >= 9,
+        timeout=REFRESH_INTERVAL * 3,
+    )
 
 
 @responses.activate
@@ -326,7 +269,7 @@ def test_uc_is_enabled_basic(readyable_unleash_client):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
 
     assert unleash_client.is_enabled("testFlag")
 
@@ -368,7 +311,7 @@ def test_uc_project(readyable_unleash_client_project):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("ivan-project")
 
 
@@ -395,7 +338,7 @@ def test_uc_fallbackfunction(readyable_unleash_client, mocker):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     # Non-existent feature flag, fallback_function
     assert unleash_client.is_enabled("notFoundTestFlag", fallback_function=fallback_spy)
     assert fallback_spy.call_count == 1
@@ -424,13 +367,13 @@ def test_uc_dirty_cache(readyable_unleash_client_nodestroy):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("testFlag")
     unleash_client.unleash_scheduler.shutdown()
 
     # Check that everything works if previous cache exists.
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("testFlag")
 
 
@@ -457,7 +400,7 @@ def test_uc_is_enabled_with_context():
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
 
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("testContextFlag")
     unleash_client.destroy()
 
@@ -474,7 +417,7 @@ def test_uc_is_enabled_error_states(readyable_unleash_client):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert not unleash_client.is_enabled("ThisFlagDoesn'tExist")
     assert unleash_client.is_enabled(
         "ThisFlagDoesn'tExist", fallback_function=lambda x, y: True
@@ -536,7 +479,7 @@ def test_uc_get_variant():
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
 
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     # If feature flag is on.
     variant = unleash_client.get_variant("testVariations", context={"userId": "2"})
     assert variant["name"] == "VarA"
@@ -597,7 +540,7 @@ def test_uc_metrics(readyable_unleash_client):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("testFlag")
 
     metrics = unleash_client.engine.get_metrics()["toggles"]
@@ -615,7 +558,7 @@ def test_uc_registers_metrics_for_nonexistent_features(readyable_unleash_client)
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
 
     # Check a flag that doesn't exist
     unleash_client.is_enabled("nonexistent-flag")
@@ -637,7 +580,7 @@ def test_uc_metrics_dependencies(readyable_unleash_client):
     )
 
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("Child")
 
     metrics = unleash_client.engine.get_metrics()["toggles"]
@@ -658,7 +601,7 @@ def test_uc_registers_variant_metrics_for_nonexistent_features(
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
 
     # Check a flag that doesn't exist
     unleash_client.get_variant("nonexistent-flag")
@@ -682,7 +625,7 @@ def test_uc_doesnt_count_metrics_for_dependency_parents(readyable_unleash_client
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
 
     child = "ChildWithVariant"
     parent = "Parent"
@@ -713,7 +656,7 @@ def test_uc_counts_metrics_for_child_even_if_parent_is_disabled(
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
 
     child = "WithDisabledDependency"
     parent = "Disabled"
@@ -740,7 +683,7 @@ def test_uc_disabled_registration(readyable_unleash_client_toggle_only):
 
     unleash_client.initialize_client()
     unleash_client.is_enabled("testFlag")
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_enabled("testFlag")
 
     for api_call in responses.calls:
@@ -763,7 +706,7 @@ def test_uc_server_error(readyable_unleash_client):
     responses.add(
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
-    ready_signal.wait(REFRESH_INTERVAL * 2)
+    assert ready_signal.wait(REFRESH_INTERVAL * 3)
     assert unleash_client.is_enabled("testFlag")
 
 
@@ -805,7 +748,7 @@ def test_uc_multiple_initializations(readyable_unleash_client):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_initialized
     assert len(unleash_client.feature_definitions()) >= 4
 
@@ -848,7 +791,7 @@ def test_uc_cache_bootstrap_dict(cache):
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_initialized
     assert len(unleash_client.feature_definitions()) >= 4
     assert unleash_client.is_enabled("testFlag")
@@ -936,7 +879,7 @@ def test_uc_custom_scheduler():
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
     assert unleash_client.is_initialized
     assert len(unleash_client.feature_definitions()) >= 4
 
@@ -957,8 +900,10 @@ def test_uc_custom_scheduler():
         status=200,
         headers={"etag": "W/somethingelse"},
     )
-    fetch_signal.wait(timeout=REFRESH_INTERVAL * 3)
-    assert len(unleash_client.feature_definitions()) >= 9
+    assert wait_until(
+        lambda: len(unleash_client.feature_definitions()) >= 9,
+        timeout=REFRESH_INTERVAL * 3,
+    )
     unleash_client.destroy()
 
 
@@ -1083,27 +1028,7 @@ def test_signals_feature_flag(cache):
     responses.add(
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
-    flag_event = None
-    variant_event = None
-
-    # Set up signals
-    send_data = signal("send-data")
-    ready_signal = threading.Event()
-
-    @send_data.connect
-    def receive_data(sender, **kw):
-        #  variant_event
-        if kw["data"].event_type == UnleashEventType.FEATURE_FLAG:
-            nonlocal flag_event
-            flag_event = kw["data"]
-        elif kw["data"].event_type == UnleashEventType.VARIANT:
-            nonlocal variant_event
-            variant_event = kw["data"]
-        elif kw["data"].event_type == UnleashEventType.READY:
-            ready_signal.set()
-
-    def example_callback(event: UnleashEvent):
-        send_data.send("anonymous", data=event)
+    recorder = EventRecorder()
 
     # Set up Unleash
     unleash_client = UnleashClient(
@@ -1113,23 +1038,30 @@ def test_signals_feature_flag(cache):
         disable_registration=True,
         disable_metrics=True,
         cache=cache,
-        event_callback=example_callback,
+        event_callback=recorder,
     )
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert recorder.ready.wait(timeout=WAIT_TIMEOUT)
 
     assert unleash_client.is_enabled("testFlag")
     variant = unleash_client.get_variant("testVariations", context={"userId": "2"})
     assert variant["name"] == "VarA"
 
-    assert flag_event.feature_name == "testFlag"
-    assert flag_event.enabled
+    # Impression events are delivered by the dispatcher, so they arrive after
+    # the call that produced them has already returned.
+    flag_events = recorder.wait_for(UnleashEventType.FEATURE_FLAG)
+    variant_events = recorder.wait_for(UnleashEventType.VARIANT)
+    assert flag_events is not None
+    assert variant_events is not None
 
-    assert variant_event.feature_name == "testVariations"
-    assert variant_event.enabled
-    assert variant_event.variant == "VarA"
+    assert flag_events[0].feature_name == "testFlag"
+    assert flag_events[0].enabled
+
+    assert variant_events[0].feature_name == "testVariations"
+    assert variant_events[0].enabled
+    assert variant_events[0].variant == "VarA"
     unleash_client.destroy()
 
 
@@ -1141,22 +1073,7 @@ def test_fetch_signal(cache):
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
     responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
-    trapped_event = None
-
-    # Set up signals
-    send_data = signal("send-data")
-    fetch_signal = threading.Event()
-
-    @send_data.connect
-    def receive_data(sender, **kw):
-
-        if kw["data"].event_type == UnleashEventType.FETCHED:
-            nonlocal trapped_event
-            trapped_event = kw["data"]
-            fetch_signal.set()
-
-    def example_callback(event: UnleashEvent):
-        send_data.send("anonymous", data=event)
+    recorder = EventRecorder()
 
     # Set up Unleash
     unleash_client = UnleashClient(
@@ -1165,14 +1082,16 @@ def test_fetch_signal(cache):
         refresh_interval=REFRESH_INTERVAL,
         metrics_interval=METRICS_INTERVAL,
         cache=cache,
-        event_callback=example_callback,
+        event_callback=recorder,
     )
 
     # Create Unleash client and check initial load
     unleash_client.initialize_client()
-    fetch_signal.wait(timeout=1)
+    fetched = recorder.wait_for(UnleashEventType.FETCHED)
+    assert fetched is not None
 
-    assert trapped_event.features[0]["name"] == "testFlag"
+    assert fetched[0].features[0]["name"] == "testFlag"
+    unleash_client.destroy()
 
 
 @responses.activate
@@ -1180,21 +1099,7 @@ def test_ready_signal(cache):
     responses.add(
         responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
     )
-    trapped_events = 0
-
-    # Set up signals
-    send_data = signal("send-data")
-    ready_signal = threading.Event()
-
-    @send_data.connect
-    def receive_data(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            nonlocal trapped_events
-            trapped_events += 1
-            ready_signal.set()
-
-    def example_callback(event: UnleashEvent):
-        send_data.send("anonymous", data=event)
+    recorder = EventRecorder()
 
     unleash_client = UnleashClient(
         URL,
@@ -1203,34 +1108,24 @@ def test_ready_signal(cache):
         disable_metrics=True,
         disable_registration=True,
         cache=cache,
-        event_callback=example_callback,
+        event_callback=recorder,
     )
 
     unleash_client.initialize_client()
-    ready_signal.wait(timeout=1)
+    assert recorder.ready.wait(timeout=WAIT_TIMEOUT)
 
-    assert trapped_events == 1
+    # Every poll emits READY again; destroy() drains whatever is still queued.
+    time.sleep(REFRESH_INTERVAL * 2)
     unleash_client.destroy()
+
+    assert len(recorder.of_type(UnleashEventType.READY)) == 1
 
 
 def test_ready_signal_works_with_bootstrapping():
     cache = FileCache("MOCK_CACHE")
     cache.bootstrap_from_dict(MOCK_FEATURE_WITH_DEPENDENCIES_RESPONSE)
 
-    trapped_events = 0
-
-    # Set up signals
-    send_data = signal("send-data")
-    ready_signal = threading.Event()
-
-    @send_data.connect
-    def receive_data(sender, **kw):
-        if kw["data"].event_type == UnleashEventType.READY:
-            nonlocal trapped_events
-            trapped_events += 1
-
-    def example_callback(event: UnleashEvent):
-        send_data.send("anonymous", data=event)
+    recorder = EventRecorder()
 
     unleash_client = UnleashClient(
         url=URL,
@@ -1238,13 +1133,13 @@ def test_ready_signal_works_with_bootstrapping():
         cache=cache,
         disable_metrics=True,
         disable_registration=True,
-        event_callback=example_callback,
+        event_callback=recorder,
     )
 
     unleash_client.initialize_client(fetch_toggles=False)
-    ready_signal.wait(timeout=1)
+    assert recorder.ready.wait(timeout=WAIT_TIMEOUT)
 
-    assert trapped_events == 1
+    assert len(recorder.of_type(UnleashEventType.READY)) == 1
 
     unleash_client.destroy()
 
@@ -1630,3 +1525,121 @@ def test_destroy_calls_custom_cache_destroy():
     unleash_client.destroy()
 
     assert cache.destroy_calls == 1
+
+
+def bootstrapped_client(recorder, **kwargs):
+    cache = FileCache("MOCK_CACHE")
+    cache.bootstrap_from_dict(MOCK_FEATURE_RESPONSE)
+    return UnleashClient(
+        URL,
+        APP_NAME,
+        cache=cache,
+        disable_metrics=True,
+        disable_registration=True,
+        event_callback=recorder,
+        **kwargs,
+    )
+
+
+def test_impression_events_are_delivered_off_the_calling_thread():
+    calling_thread = threading.current_thread()
+    callback_threads = []
+
+    def record_thread(event):
+        callback_threads.append(threading.current_thread())
+
+    unleash_client = bootstrapped_client(record_thread)
+    unleash_client.initialize_client(fetch_toggles=False)
+
+    assert unleash_client.is_enabled("testFlag")
+    unleash_client.destroy()
+
+    assert callback_threads
+    assert all(thread is not calling_thread for thread in callback_threads)
+    assert all(thread.name == "UnleashEventDispatcher" for thread in callback_threads)
+
+
+def test_is_enabled_does_not_block_on_a_slow_callback():
+    release = threading.Event()
+    recorder = EventRecorder()
+
+    def wedged_callback(event):
+        release.wait(timeout=WAIT_TIMEOUT)
+        recorder(event)
+
+    unleash_client = bootstrapped_client(wedged_callback)
+    unleash_client.initialize_client(fetch_toggles=False)
+
+    try:
+        start = time.monotonic()
+        for _ in range(50):
+            assert unleash_client.is_enabled("testFlag")
+        elapsed = time.monotonic() - start
+    finally:
+        release.set()
+
+    # The callback is wedged for the whole loop, so anything close to a second
+    # means it's being called on the hot path again.
+    assert elapsed < 1
+
+    unleash_client.destroy()
+    # Guards against the timing assertion passing because nothing was emitted.
+    assert recorder.of_type(UnleashEventType.FEATURE_FLAG)
+
+
+def test_destroy_drains_queued_events():
+    release = threading.Event()
+    recorder = EventRecorder()
+
+    def gated_callback(event):
+        release.wait(timeout=WAIT_TIMEOUT)
+        recorder(event)
+
+    unleash_client = bootstrapped_client(gated_callback)
+    unleash_client.initialize_client(fetch_toggles=False)
+
+    for _ in range(5):
+        unleash_client.is_enabled("testFlag")
+
+    release.set()
+    unleash_client.destroy()
+
+    assert len(recorder.of_type(UnleashEventType.FEATURE_FLAG)) == 5
+
+
+def test_callback_exception_does_not_break_is_enabled_or_get_variant():
+    recorder = EventRecorder()
+    first_call = True
+
+    def exploding_callback(event):
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            raise ValueError("callbacks can misbehave")
+        recorder(event)
+
+    unleash_client = bootstrapped_client(exploding_callback)
+    unleash_client.initialize_client(fetch_toggles=False)
+
+    assert unleash_client.is_enabled("testFlag")
+    variant = unleash_client.get_variant("testVariations", context={"userId": "2"})
+    assert variant["name"] == "VarA"
+
+    unleash_client.destroy()
+
+    # The first event blew up; the worker survived to deliver the rest.
+    assert recorder.events
+
+
+def test_events_emitted_after_destroy_are_dropped():
+    recorder = EventRecorder()
+
+    unleash_client = bootstrapped_client(recorder)
+    unleash_client.initialize_client(fetch_toggles=False)
+    unleash_client.destroy()
+
+    delivered_before = len(recorder.events)
+    assert delivered_before, "expected destroy() to have drained the queued events"
+
+    assert unleash_client.is_enabled("testFlag")
+    assert len(recorder.events) == delivered_before

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -1583,11 +1583,13 @@ def test_is_enabled_does_not_block_on_a_slow_callback():
     assert elapsed < 1
 
     unleash_client.destroy()
-    # Guards against the timing assertion passing because nothing was emitted.
-    assert recorder.of_type(UnleashEventType.FEATURE_FLAG)
+
+    # Because ``destroy`` is lossy, events won't be delivered. This assertion
+    # is more of a sanity check rather than a hard constraint.
+    assert not recorder.of_type(UnleashEventType.FEATURE_FLAG)
 
 
-def test_destroy_drains_queued_events():
+def test_destroy_loses_queued_events():
     release = threading.Event()
     recorder = EventRecorder()
 
@@ -1604,7 +1606,7 @@ def test_destroy_drains_queued_events():
     release.set()
     unleash_client.destroy()
 
-    assert len(recorder.of_type(UnleashEventType.FEATURE_FLAG)) == 5
+    assert len(recorder.of_type(UnleashEventType.FEATURE_FLAG)) == 0
 
 
 def test_callback_exception_does_not_break_is_enabled_or_get_variant():

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -1584,10 +1584,6 @@ def test_is_enabled_does_not_block_on_a_slow_callback():
 
     unleash_client.destroy()
 
-    # Because ``destroy`` is lossy, events won't be delivered. This assertion
-    # is more of a sanity check rather than a hard constraint.
-    assert not recorder.of_type(UnleashEventType.FEATURE_FLAG)
-
 
 def test_destroy_loses_queued_events():
     release = threading.Event()

--- a/tests/unit_tests/connectors/test_offline_connector.py
+++ b/tests/unit_tests/connectors/test_offline_connector.py
@@ -67,7 +67,7 @@ def test_offline_connector_emits_ready_event(
     )
 
     connector.start()
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    dispatcher.close(timeout=WAIT_TIMEOUT)
     connector.stop()
 
     # start() emits once via load_features() and once directly; the dispatcher

--- a/tests/unit_tests/connectors/test_offline_connector.py
+++ b/tests/unit_tests/connectors/test_offline_connector.py
@@ -3,9 +3,11 @@ import json
 from apscheduler.schedulers.background import BackgroundScheduler
 from yggdrasil_engine.engine import UnleashEngine
 
+from tests.utilities.events import WAIT_TIMEOUT, EventRecorder
 from tests.utilities.mocks.mock_features import MOCK_FEATURE_RESPONSE
 from UnleashClient.connectors import OfflineConnector
 from UnleashClient.constants import FEATURES_URL
+from UnleashClient.events import EventDispatcher, UnleashEventType
 
 
 def test_offline_connector_load_features(cache_empty):
@@ -49,25 +51,43 @@ def test_offline_connector_start_stop(cache_empty):
     scheduler.shutdown()
 
 
-def test_offline_connector_ready_callback(cache_empty):
+def test_offline_connector_emits_ready_event(
+    cache_empty, dispatcher: EventDispatcher, recorder: EventRecorder
+):
     engine = UnleashEngine()
     scheduler = BackgroundScheduler()
     temp_cache = cache_empty
     temp_cache.set(FEATURES_URL, json.dumps(MOCK_FEATURE_RESPONSE))
 
-    callback_called = False
+    connector = OfflineConnector(
+        engine=engine,
+        cache=temp_cache,
+        scheduler=scheduler,
+        events=dispatcher,
+    )
 
-    def ready_callback():
-        nonlocal callback_called
-        callback_called = True
+    connector.start()
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    connector.stop()
+
+    # start() emits once via load_features() and once directly; the dispatcher
+    # collapses those into a single delivery.
+    assert len(recorder.of_type(UnleashEventType.READY)) == 1
+
+
+def test_offline_connector_without_a_dispatcher_does_not_emit(cache_empty):
+    engine = UnleashEngine()
+    scheduler = BackgroundScheduler()
+    temp_cache = cache_empty
+    temp_cache.set(FEATURES_URL, json.dumps(MOCK_FEATURE_RESPONSE))
 
     connector = OfflineConnector(
         engine=engine,
         cache=temp_cache,
         scheduler=scheduler,
-        ready_callback=ready_callback,
     )
 
     connector.start()
-    assert callback_called
+    assert connector._events is None
+    assert engine.is_enabled("testFlag", {})
     connector.stop()

--- a/tests/unit_tests/connectors/test_polling_connector.py
+++ b/tests/unit_tests/connectors/test_polling_connector.py
@@ -147,7 +147,7 @@ def test_polling_connector_emits_fetched_and_ready(
     )
 
     connector._fetch_and_load()
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    dispatcher.close(timeout=WAIT_TIMEOUT)
 
     fetched = recorder.of_type(UnleashEventType.FETCHED)
     assert len(fetched) == 1
@@ -182,7 +182,7 @@ def test_polling_connector_emits_ready_once_across_polls(
     # Every poll emits READY twice, once from load_features() and once directly.
     connector._fetch_and_load()
     connector._fetch_and_load()
-    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+    dispatcher.close(timeout=WAIT_TIMEOUT)
 
     assert len(recorder.of_type(UnleashEventType.READY)) == 1
     assert len(recorder.of_type(UnleashEventType.FETCHED)) == 2

--- a/tests/unit_tests/connectors/test_polling_connector.py
+++ b/tests/unit_tests/connectors/test_polling_connector.py
@@ -144,15 +144,17 @@ def test_polling_connector_emits_fetched_and_ready(
         request_timeout=REQUEST_TIMEOUT,
         request_retries=REQUEST_RETRIES,
         events=dispatcher,
+        # Huge refresh interval to avoid any polling during the test. That
+        # way we avoid having to call _fetch_and_load() directly and can test the start/stop behavior.
+        refresh_interval=10,
     )
 
-    connector._fetch_and_load()
-    dispatcher.close(timeout=WAIT_TIMEOUT)
+    connector.start()
+    connector.stop()  # Immediately stop, so _get_and_load() is called only once and we can assert the events emitted.
 
-    fetched = recorder.of_type(UnleashEventType.FETCHED)
-    assert len(fetched) == 1
-    assert fetched[0].features[0]["name"] == "testFlag"
-    assert len(recorder.of_type(UnleashEventType.READY)) == 1
+    assert recorder.wait_for(UnleashEventType.READY, count=1)
+    assert recorder.wait_for(UnleashEventType.FETCHED, count=1)
+    dispatcher.close(timeout=WAIT_TIMEOUT)
 
 
 @responses.activate
@@ -186,33 +188,6 @@ def test_polling_connector_emits_ready_once_across_polls(
 
     assert len(recorder.of_type(UnleashEventType.READY)) == 1
     assert len(recorder.of_type(UnleashEventType.FETCHED)) == 2
-
-
-@responses.activate
-def test_polling_connector_without_a_dispatcher_does_not_emit(cache_empty):
-    engine = UnleashEngine()
-    scheduler = BackgroundScheduler()
-    responses.add(
-        responses.GET, FULL_FEATURE_URL, json=MOCK_FEATURE_RESPONSE, status=200
-    )
-
-    connector = PollingConnector(
-        engine=engine,
-        cache=cache_empty,
-        scheduler=scheduler,
-        url=URL,
-        app_name=APP_NAME,
-        instance_id=INSTANCE_ID,
-        headers=CUSTOM_HEADERS,
-        custom_options=CUSTOM_OPTIONS,
-        request_timeout=REQUEST_TIMEOUT,
-        request_retries=REQUEST_RETRIES,
-    )
-
-    connector._fetch_and_load()
-
-    assert connector._events is None
-    assert engine.is_enabled("testFlag", {})
 
 
 @responses.activate

--- a/tests/unit_tests/connectors/test_polling_connector.py
+++ b/tests/unit_tests/connectors/test_polling_connector.py
@@ -2,6 +2,7 @@ import responses
 from apscheduler.schedulers.background import BackgroundScheduler
 from yggdrasil_engine.engine import UnleashEngine
 
+from tests.utilities.events import WAIT_TIMEOUT, EventRecorder
 from tests.utilities.mocks.mock_features import (
     MOCK_FEATURE_RESPONSE,
     MOCK_FEATURE_RESPONSE_PROJECT,
@@ -20,6 +21,7 @@ from tests.utilities.testing_constants import (
 )
 from UnleashClient.connectors import PollingConnector
 from UnleashClient.constants import ETAG, FEATURES_URL
+from UnleashClient.events import EventDispatcher, UnleashEventType
 
 FULL_FEATURE_URL = URL + FEATURES_URL
 
@@ -113,6 +115,103 @@ def test_polling_connector_fetch_and_load_failure(cache_empty):
 
     connector._fetch_and_load()
 
+    assert engine.is_enabled("testFlag", {})
+
+
+@responses.activate
+def test_polling_connector_emits_fetched_and_ready(
+    cache_empty, dispatcher: EventDispatcher, recorder: EventRecorder
+):
+    engine = UnleashEngine()
+    scheduler = BackgroundScheduler()
+    responses.add(
+        responses.GET,
+        FULL_FEATURE_URL,
+        json=MOCK_FEATURE_RESPONSE,
+        status=200,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    connector = PollingConnector(
+        engine=engine,
+        cache=cache_empty,
+        scheduler=scheduler,
+        url=URL,
+        app_name=APP_NAME,
+        instance_id=INSTANCE_ID,
+        headers=CUSTOM_HEADERS,
+        custom_options=CUSTOM_OPTIONS,
+        request_timeout=REQUEST_TIMEOUT,
+        request_retries=REQUEST_RETRIES,
+        events=dispatcher,
+    )
+
+    connector._fetch_and_load()
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+
+    fetched = recorder.of_type(UnleashEventType.FETCHED)
+    assert len(fetched) == 1
+    assert fetched[0].features[0]["name"] == "testFlag"
+    assert len(recorder.of_type(UnleashEventType.READY)) == 1
+
+
+@responses.activate
+def test_polling_connector_emits_ready_once_across_polls(
+    cache_empty, dispatcher, recorder
+):
+    engine = UnleashEngine()
+    scheduler = BackgroundScheduler()
+    responses.add(
+        responses.GET, FULL_FEATURE_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+
+    connector = PollingConnector(
+        engine=engine,
+        cache=cache_empty,
+        scheduler=scheduler,
+        url=URL,
+        app_name=APP_NAME,
+        instance_id=INSTANCE_ID,
+        headers=CUSTOM_HEADERS,
+        custom_options=CUSTOM_OPTIONS,
+        request_timeout=REQUEST_TIMEOUT,
+        request_retries=REQUEST_RETRIES,
+        events=dispatcher,
+    )
+
+    # Every poll emits READY twice, once from load_features() and once directly.
+    connector._fetch_and_load()
+    connector._fetch_and_load()
+    assert dispatcher.flush(timeout=WAIT_TIMEOUT)
+
+    assert len(recorder.of_type(UnleashEventType.READY)) == 1
+    assert len(recorder.of_type(UnleashEventType.FETCHED)) == 2
+
+
+@responses.activate
+def test_polling_connector_without_a_dispatcher_does_not_emit(cache_empty):
+    engine = UnleashEngine()
+    scheduler = BackgroundScheduler()
+    responses.add(
+        responses.GET, FULL_FEATURE_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+
+    connector = PollingConnector(
+        engine=engine,
+        cache=cache_empty,
+        scheduler=scheduler,
+        url=URL,
+        app_name=APP_NAME,
+        instance_id=INSTANCE_ID,
+        headers=CUSTOM_HEADERS,
+        custom_options=CUSTOM_OPTIONS,
+        request_timeout=REQUEST_TIMEOUT,
+        request_retries=REQUEST_RETRIES,
+    )
+
+    connector._fetch_and_load()
+
+    assert connector._events is None
     assert engine.is_enabled("testFlag", {})
 
 

--- a/tests/utilities/events.py
+++ b/tests/utilities/events.py
@@ -1,0 +1,73 @@
+import threading
+import time
+from typing import List, Optional
+
+from UnleashClient.events import BaseEvent, UnleashEventType
+
+WAIT_TIMEOUT = 5
+
+
+class EventRecorder:
+    """
+    An event callback that records everything the dispatcher delivers.
+
+    Events now arrive on a background thread, so tests need something to wait on
+    rather than asserting straight after the call that produced the event.
+    """
+
+    def __init__(self) -> None:
+        self.events: List[BaseEvent] = []
+        self.ready = threading.Event()
+        self.fetched = threading.Event()
+        self._condition = threading.Condition()
+
+    def __call__(self, event: BaseEvent) -> None:
+        with self._condition:
+            self.events.append(event)
+            self._condition.notify_all()
+
+        if event.event_type == UnleashEventType.READY:
+            self.ready.set()
+        if event.event_type == UnleashEventType.FETCHED:
+            self.fetched.set()
+
+    def of_type(self, event_type: UnleashEventType) -> List[BaseEvent]:
+        with self._condition:
+            return [event for event in self.events if event.event_type == event_type]
+
+    def wait_for(
+        self,
+        event_type: UnleashEventType,
+        count: int = 1,
+        timeout: float = WAIT_TIMEOUT,
+    ) -> Optional[List[BaseEvent]]:
+        """
+        Blocks until ``count`` events of ``event_type`` have been delivered.
+
+        :return: The matching events, or None if they didn't arrive in time.
+        """
+        deadline = time.monotonic() + timeout
+
+        with self._condition:
+            while len(self._matching(event_type)) < count:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not self._condition.wait(remaining):
+                    return None
+            return self._matching(event_type)[:count]
+
+    def _matching(self, event_type: UnleashEventType) -> List[BaseEvent]:
+        return [event for event in self.events if event.event_type == event_type]
+
+
+def wait_until(
+    predicate, timeout: float = WAIT_TIMEOUT, interval: float = 0.05
+) -> bool:
+    """
+    Polls ``predicate`` until it's true, for cases where there's no event to wait on.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())

--- a/tests/utilities/events.py
+++ b/tests/utilities/events.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from threading import Condition, Event
 from typing import List, Optional
 
 from UnleashClient.events import BaseEvent, UnleashEventType
@@ -17,9 +18,9 @@ class EventRecorder:
 
     def __init__(self) -> None:
         self.events: List[BaseEvent] = []
-        self.ready = threading.Event()
-        self.fetched = threading.Event()
-        self._condition = threading.Condition()
+        self.ready: Event = threading.Event()
+        self.fetched: Event = threading.Event()
+        self._condition: Condition = threading.Condition()
 
     def __call__(self, event: BaseEvent) -> None:
         with self._condition:


### PR DESCRIPTION
## Summary

This pull request wires the EventDispatcher to the UnleashClient and its connectors. It changes all connectors from expecting an `event_callback`
(and, in some instances, a `ready_callback`) to accepting an instance
of the newly created EventDispatcher.


## Tricky things when reviewing

### `unleash_event_callback` instance variable

After reviewing https://github.com/Unleash/unleash-python-sdk/pull/243, it seems like that property was not meant to be public.
Furthermore, it is not mentioned in any docs. However, it would be a breaking
change to remove it, and rude to any users who might be using it.

I'd clean it up otherwise.

### events.py utilities

Testing a dispatcher of events that uses Threads is hard. I've introduced
an `EventRecorder` helper class that aids in testing that the publishing
of events works as intended without having to poke the internals of
the class being tested.

I agree, though, that it can be funny. I'm happy to review this decision if
better alternatives come to mind.

### asserting awaited signals

Because the callback ran in the same thread as tests, ensuring signals
were awaited instead of timed out made sense:

```
    ready_signal.wait(timeout=1) # We don't care about the return value
```

Callbacks run in another thread now, so asserting these waits makes
more sense:

```
    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
```

### `BoostrapConnector` behaves funny

Two things worth noting about this connector:

1. It does not emit events because it never accepted a callback in the
first place.
2. It's the only connector which `start()` function is called in the
`UnleashClient` constructor.
