### PR TITLE
feat!: migrate to bindings v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Unreleased
 * (Minor): Upgraded to yggdrasil-engine 2.0. Counting toggle and variant evaluations, and deciding whether an impression event is due, now happen inside the engine rather than in the SDK. `is_enabled()` and `get_variant()` return the same types as before, so no calling code needs to change.
 * (Minor): A `fallback_function` that raises now results in `False` and a logged warning, instead of the exception propagating out of `is_enabled()`. The toggle is not counted in that case.
-* (Minor): Resolving a feature flag into an impact metric label now also records a flag evaluation in the metrics bucket, because the engine counts every variant lookup.
 * (Minor): Event callbacks are now invoked on a dedicated background thread instead of on whichever thread produced the event. `is_enabled()` and `get_variant()` no longer wait for your callback, so a slow callback can't hold up flag evaluation. Three consequences worth knowing about: callbacks can no longer read thread local state from the caller (Flask `g`, the current Django request, contextvars); they return before the callback has run, so tests asserting straight after the call now need to wait; and reassigning `unleash_event_callback` after construction is no longer honoured.
 * (Minor): Connectors take an `EventDispatcher` instead of `ready_callback`/`event_callback`. These classes aren't part of the documented API, so this only affects code importing from `UnleashClient.connectors` directly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+* (Minor): Upgraded to yggdrasil-engine 2.0. Counting toggle and variant evaluations, and deciding whether an impression event is due, now happen inside the engine rather than in the SDK. `is_enabled()` and `get_variant()` return the same types as before, so no calling code needs to change.
+* (Minor): A `fallback_function` that raises now results in `False` and a logged warning, instead of the exception propagating out of `is_enabled()`. The toggle is not counted in that case.
+* (Minor): Resolving a feature flag into an impact metric label now also records a flag evaluation in the metrics bucket, because the engine counts every variant lookup.
 * (Minor): Event callbacks are now invoked on a dedicated background thread instead of on whichever thread produced the event. `is_enabled()` and `get_variant()` no longer wait for your callback, so a slow callback can't hold up flag evaluation. Three consequences worth knowing about: callbacks can no longer read thread local state from the caller (Flask `g`, the current Django request, contextvars); they return before the callback has run, so tests asserting straight after the call now need to wait; and reassigning `unleash_event_callback` after construction is no longer honoured.
 * (Minor): Connectors take an `EventDispatcher` instead of `ready_callback`/`event_callback`. These classes aren't part of the documented API, so this only affects code importing from `UnleashClient.connectors` directly.
 

--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -28,7 +28,6 @@ from UnleashClient.connectors import (
 )
 from UnleashClient.constants import (
     APPLICATION_HEADERS,
-    DISABLED_VARIATION,
     ETAG,
     METRIC_LAST_SENT_TIME,
     REQUEST_RETRIES,
@@ -535,17 +534,6 @@ class UnleashClient:
         redacted_secret = f"{secret[:6]}...{secret[-3:]}"
         return f"{prefix}{separator}{redacted_secret}"
 
-    @staticmethod
-    def _get_fallback_value(
-        fallback_function: Callable, feature_name: str, context: dict
-    ) -> bool:
-        if fallback_function:
-            fallback_value = fallback_function(feature_name, context)
-        else:
-            fallback_value = False
-
-        return fallback_value
-
     # pylint: disable=broad-except
     def is_enabled(
         self,
@@ -566,22 +554,18 @@ class UnleashClient:
         :return: Feature flag result
         """
         context = self._safe_context(context)
-        feature_enabled = self.engine.is_enabled(feature_name, context)
+        result = self.engine.is_enabled(
+            feature_name, context, fallback_function=fallback_function
+        )
 
-        if feature_enabled is None:
-            feature_enabled = self._get_fallback_value(
-                fallback_function, feature_name, context
-            )
-
-        self.engine.count_toggle(feature_name, feature_enabled)
         try:
-            if self.__events and self.engine.should_emit_impression_event(feature_name):
+            if self.__events and result.requires_impression_event_emission:
                 self.__events.emit_event(
                     UnleashEvent(
                         event_type=UnleashEventType.FEATURE_FLAG,
                         event_id=uuid.uuid4(),
                         context=context,
-                        enabled=feature_enabled,
+                        enabled=result.is_enabled,
                         feature_name=feature_name,
                     )
                 )
@@ -592,7 +576,7 @@ class UnleashClient:
                 excep,
             )
 
-        return feature_enabled
+        return result.is_enabled
 
     # pylint: disable=broad-except
     def get_variant(self, feature_name: str, context: Optional[dict] = None) -> dict:
@@ -608,30 +592,25 @@ class UnleashClient:
         :return: Variant and feature flag status.
         """
         context = self._safe_context(context)
-        variant = self._resolve_variant(feature_name, context)
+        result = self.engine.get_variant(feature_name, context)
 
-        if not variant:
-            if self.unleash_bootstrapped or self.is_initialized:
-                LOGGER.log(
-                    self.unleash_verbose_log_level,
-                    "Attempted to get feature flag/variation %s, but client wasn't initialized!",
-                    feature_name,
-                )
-            variant = DISABLED_VARIATION
-
-        self.engine.count_variant(feature_name, variant["name"])
-        self.engine.count_toggle(feature_name, variant["feature_enabled"])
+        if not result.is_found and (self.unleash_bootstrapped or self.is_initialized):
+            LOGGER.log(
+                self.unleash_verbose_log_level,
+                "Attempted to get feature flag/variation %s, but client wasn't initialized!",
+                feature_name,
+            )
 
         try:
-            if self.__events and self.engine.should_emit_impression_event(feature_name):
+            if self.__events and result.requires_impression_event_emission:
                 self.__events.emit_event(
                     UnleashEvent(
                         event_type=UnleashEventType.VARIANT,
                         event_id=uuid.uuid4(),
                         context=context,
-                        enabled=bool(variant["enabled"]),
+                        enabled=bool(result.variant.enabled),
                         feature_name=feature_name,
-                        variant=str(variant["name"]),
+                        variant=str(result.variant.name),
                     )
                 )
         except Exception as excep:
@@ -641,6 +620,8 @@ class UnleashClient:
                 excep,
             )
 
+        # This can probably become a to_dict method of the Variant type.
+        variant = {k: v for k, v in asdict(result.variant).items() if v is not None}
         return variant
 
     def _safe_context(self, context) -> dict:
@@ -678,15 +659,6 @@ class UnleashClient:
         if isinstance(value, (int, float)):
             return str(value)
         return str(value)
-
-    def _resolve_variant(self, feature_name: str, context: dict) -> dict:
-        """
-        Resolves a feature variant.
-        """
-        variant = self.engine.get_variant(feature_name, context)
-        if variant:
-            return {k: v for k, v in asdict(variant).items() if v is not None}
-        return None
 
     def _do_instance_check(self, multiple_instance_mode):
         identifier = self.__get_identifier()

--- a/UnleashClient/impact_metrics.py
+++ b/UnleashClient/impact_metrics.py
@@ -64,7 +64,7 @@ class ImpactMetrics:
         self._engine.observe_histogram(name, value, labels)
 
     def _variant_label(self, flag_name: str, context: Dict[str, Any]) -> str:
-        variant = self._engine.get_variant(flag_name, context).variant
+        variant = self._engine.check_variant(flag_name, context).variant
         if variant.enabled:
             return variant.name
         if variant.feature_enabled:

--- a/UnleashClient/impact_metrics.py
+++ b/UnleashClient/impact_metrics.py
@@ -64,10 +64,10 @@ class ImpactMetrics:
         self._engine.observe_histogram(name, value, labels)
 
     def _variant_label(self, flag_name: str, context: Dict[str, Any]) -> str:
-        variant = self._engine.get_variant(flag_name, context)
-        if variant and variant.enabled:
+        variant = self._engine.get_variant(flag_name, context).variant
+        if variant.enabled:
             return variant.name
-        if variant and variant.feature_enabled:
+        if variant.feature_enabled:
             return "enabled"
         return "disabled"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies=[
     "importlib_metadata",
     "python-dateutil",
     "semver < 4.0.0",
-    "yggdrasil-engine >= 2.0.0a0",
+    "yggdrasil-engine >= 2.0.0a1",
     "launchdarkly-eventsource",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies=[
     "importlib_metadata",
     "python-dateutil",
     "semver < 4.0.0",
-    "yggdrasil-engine >= 1.3.0",
+    "yggdrasil-engine >= 2.0.0a0",
     "launchdarkly-eventsource",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mmhash3
 python-dateutil
 requests
 semver
-yggdrasil-engine==2.0.0a0
+yggdrasil-engine==2.0.0a1
 launchdarkly-eventsource
 
 # Development packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mmhash3
 python-dateutil
 requests
 semver
-yggdrasil-engine>=1.3.0
+yggdrasil-engine==2.0.0a0
 launchdarkly-eventsource
 
 # Development packages

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -356,6 +356,96 @@ def test_uc_fallbackfunction(readyable_unleash_client, mocker):
 
 
 @responses.activate
+def test_uc_fallback_receives_feature_name_and_enriched_context(
+    readyable_unleash_client, mocker
+):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+
+    def good_fallback(feature_name: str, context: dict) -> bool:
+        return True
+
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+    fallback_spy = mocker.Mock(wraps=good_fallback)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    assert unleash_client.is_enabled(
+        "notFoundTestFlag", {"userId": "7"}, fallback_function=fallback_spy
+    )
+
+    # The engine resolves the fallback now, but it must still hand the callable
+    # the feature name and the context the client enriched.
+    feature_name, context = fallback_spy.call_args[0]
+    assert feature_name == "notFoundTestFlag"
+    assert context["userId"] == "7"
+    assert context["appName"] == APP_NAME
+    assert context["environment"] == "default"
+    assert "currentTime" in context
+    assert "properties" in context
+
+
+@responses.activate
+def test_uc_fallback_result_is_what_gets_counted(readyable_unleash_client):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    assert unleash_client.is_enabled(
+        "notFoundTestFlag", fallback_function=lambda name, context: True
+    )
+
+    # The fallback's answer is counted, not the "not found" default.
+    metrics = unleash_client.engine.get_metrics()["toggles"]
+    assert metrics["notFoundTestFlag"]["yes"] == 1
+
+
+@responses.activate
+def test_uc_raising_fallback_returns_false_and_records_nothing(
+    readyable_unleash_client,
+):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+
+    def context_fallback(feature_name: str, context: dict) -> bool:
+        return context["wat"]
+
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    # Counted so the metrics bucket exists; it's None until something lands in it.
+    assert unleash_client.is_enabled("testFlag")
+
+    # A fallback that raises used to propagate out of is_enabled. The engine now
+    # swallows and logs it, and never reaches the point where it counts the toggle.
+    assert (
+        unleash_client.is_enabled(
+            "notFoundTestFlag", fallback_function=context_fallback
+        )
+        is False
+    )
+    assert "notFoundTestFlag" not in unleash_client.engine.get_metrics()["toggles"]
+
+
+@responses.activate
 def test_uc_dirty_cache(readyable_unleash_client_nodestroy):
     unleash_client, ready_signal, _ = readyable_unleash_client_nodestroy
     # Set up API
@@ -545,6 +635,68 @@ def test_uc_metrics(readyable_unleash_client):
 
     metrics = unleash_client.engine.get_metrics()["toggles"]
     assert metrics["testFlag"]["yes"] == 1
+
+
+@responses.activate
+def test_uc_is_enabled_counts_each_call_once(readyable_unleash_client):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    for _ in range(3):
+        assert unleash_client.is_enabled("testFlag")
+
+    # The engine counts the toggle. If the client counted it too, this would be 6.
+    metrics = unleash_client.engine.get_metrics()["toggles"]
+    assert metrics["testFlag"]["yes"] == 3
+
+
+@responses.activate
+def test_uc_get_variant_counts_toggle_and_variant_once(readyable_unleash_client):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    variant = unleash_client.get_variant("testVariations", context={"userId": "2"})
+    assert variant["name"] == "VarA"
+
+    # get_variant counts both the toggle and the variant, each exactly once.
+    metrics = unleash_client.engine.get_metrics()["toggles"]
+    assert metrics["testVariations"]["yes"] == 1
+    assert metrics["testVariations"]["variants"]["VarA"] == 1
+
+
+@responses.activate
+def test_uc_is_enabled_returns_a_plain_bool(readyable_unleash_client):
+    unleash_client, ready_signal, _ = readyable_unleash_client
+    # Set up API
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(
+        responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200
+    )
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    unleash_client.initialize_client()
+    assert ready_signal.wait(timeout=WAIT_TIMEOUT)
+
+    # The engine's FeatureToggle must not leak out of the public API; it can't
+    # even be truth-tested.
+    assert unleash_client.is_enabled("testFlag") is True
+    assert unleash_client.is_enabled("notFoundTestFlag") is False
 
 
 @responses.activate

--- a/tests/unit_tests/connectors/test_offline_connector.py
+++ b/tests/unit_tests/connectors/test_offline_connector.py
@@ -24,7 +24,7 @@ def test_offline_connector_load_features(cache_empty):
     )
 
     connector.load_features()
-    assert engine.is_enabled("testFlag", {})
+    assert engine.is_enabled("testFlag", {}).is_enabled
 
 
 def test_offline_connector_start_stop(cache_empty):
@@ -89,5 +89,5 @@ def test_offline_connector_without_a_dispatcher_does_not_emit(cache_empty):
 
     connector.start()
     assert connector._events is None
-    assert engine.is_enabled("testFlag", {})
+    assert engine.is_enabled("testFlag", {}).is_enabled
     connector.stop()

--- a/tests/unit_tests/connectors/test_polling_connector.py
+++ b/tests/unit_tests/connectors/test_polling_connector.py
@@ -54,7 +54,7 @@ def test_polling_connector_fetch_and_load(cache_empty):
 
     connector._fetch_and_load()
 
-    assert engine.is_enabled("testFlag", {})
+    assert engine.is_enabled("testFlag", {}).is_enabled
     assert temp_cache.get(ETAG) == ETAG_VALUE
 
 
@@ -83,7 +83,7 @@ def test_polling_connector_fetch_and_load_project(cache_empty):
 
     connector._fetch_and_load()
 
-    assert engine.is_enabled("ivan-project", {})
+    assert engine.is_enabled("ivan-project", {}).is_enabled
 
 
 @responses.activate
@@ -115,7 +115,7 @@ def test_polling_connector_fetch_and_load_failure(cache_empty):
 
     connector._fetch_and_load()
 
-    assert engine.is_enabled("testFlag", {})
+    assert engine.is_enabled("testFlag", {}).is_enabled
 
 
 @responses.activate

--- a/tests/unit_tests/test_impact_metrics.py
+++ b/tests/unit_tests/test_impact_metrics.py
@@ -160,6 +160,25 @@ class TestSendMetricsViaClient:
             "disabled-feature": "disabled",
         }
 
+    # TODO: I'm leaving this test here as a reminder of the unintended side effect
+    # caused by having moved "count_toggle" and "count_variant" inside the engine's
+    # operations.
+    def test_flag_context_labels_record_toggle_metrics(self, unleash_client):
+        flag_context = MetricFlagContext(
+            flag_names=["feature-with-variant", "disabled-feature"],
+            context={"userId": "123"},
+        )
+
+        unleash_client.impact_metrics.define_counter("purchases", "Number of purchases")
+        unleash_client.impact_metrics.increment_counter("purchases", 1, flag_context)
+
+        # Resolving a flag into a label goes through the engine's get_variant,
+        # which records the evaluation. This is intentional, not a leak.
+        metrics = unleash_client.engine.get_metrics()["toggles"]
+        assert metrics["feature-with-variant"]["yes"] == 1
+        assert metrics["feature-with-variant"]["variants"]["treatment"] == 1
+        assert metrics["disabled-feature"]["no"] == 1
+
     @responses.activate
     def test_impact_metrics_resent_after_failure(self, unleash_client):
         responses.add(responses.POST, URL + METRICS_URL, json={}, status=500)

--- a/tests/unit_tests/test_impact_metrics.py
+++ b/tests/unit_tests/test_impact_metrics.py
@@ -160,10 +160,7 @@ class TestSendMetricsViaClient:
             "disabled-feature": "disabled",
         }
 
-    # TODO: I'm leaving this test here as a reminder of the unintended side effect
-    # caused by having moved "count_toggle" and "count_variant" inside the engine's
-    # operations.
-    def test_flag_context_labels_record_toggle_metrics(self, unleash_client):
+    def test_flag_context_labels_do_not_record_toggle_metrics(self, unleash_client):
         flag_context = MetricFlagContext(
             flag_names=["feature-with-variant", "disabled-feature"],
             context={"userId": "123"},
@@ -172,12 +169,27 @@ class TestSendMetricsViaClient:
         unleash_client.impact_metrics.define_counter("purchases", "Number of purchases")
         unleash_client.impact_metrics.increment_counter("purchases", 1, flag_context)
 
-        # Resolving a flag into a label goes through the engine's get_variant,
-        # which records the evaluation. This is intentional, not a leak.
-        metrics = unleash_client.engine.get_metrics()["toggles"]
-        assert metrics["feature-with-variant"]["yes"] == 1
-        assert metrics["feature-with-variant"]["variants"]["treatment"] == 1
-        assert metrics["disabled-feature"]["no"] == 1
+        # Resolving a flag into a label goes through the engine's check_variant,
+        # which does not count the evaluation. The engine reports no metrics
+        # bucket at all until something is counted.
+        assert unleash_client.engine.get_metrics() is None
+
+    def test_real_evaluations_are_still_counted_alongside_label_resolution(
+        self, unleash_client
+    ):
+        flag_context = MetricFlagContext(
+            flag_names=["feature-with-variant", "enabled-feature", "disabled-feature"],
+            context={"userId": "123"},
+        )
+
+        unleash_client.impact_metrics.define_counter("purchases", "Number of purchases")
+        unleash_client.impact_metrics.increment_counter("purchases", 1, flag_context)
+
+        unleash_client.is_enabled("enabled-feature")
+
+        toggles = unleash_client.engine.get_metrics()["toggles"]
+        assert list(toggles) == ["enabled-feature"]
+        assert toggles["enabled-feature"]["yes"] == 1
 
     @responses.activate
     def test_impact_metrics_resent_after_failure(self, unleash_client):


### PR DESCRIPTION
## Summary

After releasing https://github.com/Unleash/yggdrasil-bindings/pull/117, it's now the SDK's turn to use the new version of the bindings.

This new version has moved the `count_toggle`, `count_variant` and `should_emit_impression_event` inside the public methods `is_enabled` and `get_variant. As a consequence, anyone using this new version of the bindings does not need to (in fact, they must not) invoke `count_toggle` or any other helper; just `is_enabled` and `get_variant`