### PR TITLE
Fix/redact instance id in identifier

### DIFF
--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -30,7 +30,13 @@ def send_metrics(
     """
     try:
         LOGGER.info("Sending messages to with unleash @ %s", url)
-        LOGGER.info("unleash metrics information: %s", {**request_body, "instanceId": redact_to_print_safely(request_body.get("instanceId"))})
+        LOGGER.info(
+            "unleash metrics information: %s",
+            {
+                **request_body,
+                "instanceId": redact_to_print_safely(request_body.get("instanceId")),
+            },
+        )
 
         resp = requests.post(
             build_normalized_url(url, METRICS_URL),

--- a/UnleashClient/api/metrics.py
+++ b/UnleashClient/api/metrics.py
@@ -4,7 +4,7 @@ import requests
 
 from UnleashClient.api.urls import build_normalized_url
 from UnleashClient.constants import APPLICATION_HEADERS, METRICS_URL
-from UnleashClient.utils import LOGGER, log_resp_info
+from UnleashClient.utils import LOGGER, log_resp_info, redact_to_print_safely
 
 
 # pylint: disable=broad-except
@@ -30,7 +30,7 @@ def send_metrics(
     """
     try:
         LOGGER.info("Sending messages to with unleash @ %s", url)
-        LOGGER.info("unleash metrics information: %s", request_body)
+        LOGGER.info("unleash metrics information: %s", {**request_body, "instanceId": redact_to_print_safely(request_body.get("instanceId"))})
 
         resp = requests.post(
             build_normalized_url(url, METRICS_URL),

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -70,7 +70,15 @@ def register_client(
 
     try:
         LOGGER.info("Registering unleash client with unleash @ %s", url)
-        LOGGER.info("Registration request information: %s", {**registration_request, "instanceId": redact_to_print_safely(registration_request.get("instanceId"))})
+        LOGGER.info(
+            "Registration request information: %s",
+            {
+                **registration_request,
+                "instanceId": redact_to_print_safely(
+                    registration_request.get("instanceId")
+                ),
+            },
+        )
 
         resp = requests.post(
             build_normalized_url(url, REGISTER_URL),

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -15,7 +15,7 @@ from UnleashClient.constants import (
     SDK_NAME,
     SDK_VERSION,
 )
-from UnleashClient.utils import LOGGER, log_resp_info
+from UnleashClient.utils import LOGGER, log_resp_info, redact_to_print_safely
 
 
 # pylint: disable=broad-except
@@ -70,7 +70,7 @@ def register_client(
 
     try:
         LOGGER.info("Registering unleash client with unleash @ %s", url)
-        LOGGER.info("Registration request information: %s", registration_request)
+        LOGGER.info("Registration request information: %s", {**registration_request, "instanceId": redact_to_print_safely(registration_request.get("instanceId"))})
 
         resp = requests.post(
             build_normalized_url(url, REGISTER_URL),

--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -51,6 +51,7 @@ from UnleashClient.utils import (
     InstanceAllowType,
     InstanceCounter,
     extract_environment_from_headers,
+    redact_to_print_safely,
 )
 
 try:
@@ -515,11 +516,7 @@ class UnleashClient:
 
     @staticmethod
     def _redact_to_print_safely(value: Optional[str]) -> Optional[str]:
-        if not value:
-            return value
-        prefix, separator, secret = value.rpartition(":")
-        redacted_secret = f"{secret[:6]}...{secret[-3:]}"
-        return f"{prefix}{separator}{redacted_secret}"
+        return redact_to_print_safely(value)
 
     @staticmethod
     def _get_fallback_value(
@@ -695,7 +692,7 @@ class UnleashClient:
             if self.unleash_custom_headers is not None
             else None
         )
-        return f"apiKey:{self._redact_to_print_safely(api_key)} appName:{self.unleash_app_name} instanceId:{self.unleash_instance_id}"
+        return f"apiKey:{self._redact_to_print_safely(api_key)} appName:{self.unleash_app_name} instanceId:{self._redact_to_print_safely(self.unleash_instance_id)}"
 
     def __enter__(self) -> "UnleashClient":
         self.initialize_client()

--- a/UnleashClient/utils.py
+++ b/UnleashClient/utils.py
@@ -63,6 +63,14 @@ def get_identifier(context_key_name: str, context: dict) -> Any:
     return value
 
 
+def redact_to_print_safely(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return value
+    prefix, separator, secret = value.rpartition(":")
+    redacted_secret = f"{secret[:6]}...{secret[-3:]}"
+    return f"{prefix}{separator}{redacted_secret}"
+
+
 def log_resp_info(resp: Response) -> None:
     LOGGER.debug("HTTP status code: %s", resp.status_code)
     LOGGER.debug("HTTP headers: %s", resp.headers)

--- a/tests/unit_tests/api/test_metrics.py
+++ b/tests/unit_tests/api/test_metrics.py
@@ -47,6 +47,21 @@ def test_send_metrics(payload, status, expected):
 
 
 @responses.activate
+def test_instance_id_is_not_logged_in_plain_text_in_metrics(caplog):
+    responses.add(responses.POST, FULL_METRICS_URL, json={}, status=202)
+    instance_id = "abcdef1234567890ghijklmnop"
+    request_body = {**MOCK_METRICS_REQUEST, "instanceId": instance_id}
+
+    send_metrics(URL, request_body, CUSTOM_HEADERS, CUSTOM_OPTIONS, REQUEST_TIMEOUT)
+
+    assert instance_id not in caplog.text
+    assert "abcdef...nop" in caplog.text
+
+    actual_payload = json.loads(responses.calls[0].request.body)
+    assert actual_payload["instanceId"] == instance_id
+
+
+@responses.activate
 def test_send_metrics_strips_trailing_slash_from_url():
     responses.add(responses.POST, FULL_METRICS_URL, json={}, status=202)
 

--- a/tests/unit_tests/api/test_register.py
+++ b/tests/unit_tests/api/test_register.py
@@ -126,6 +126,30 @@ def test_register_omits_sdk_flavor_when_unset():
 
 
 @responses.activate
+def test_instance_id_is_not_logged_in_plain_text_in_registration(caplog):
+    responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
+    instance_id = "abcdef1234567890ghijklmnop"
+
+    register_client(
+        URL,
+        APP_NAME,
+        instance_id,
+        CONNECTION_ID,
+        METRICS_INTERVAL,
+        CUSTOM_HEADERS,
+        CUSTOM_OPTIONS,
+        {},
+        REQUEST_TIMEOUT,
+    )
+
+    assert instance_id not in caplog.text
+    assert "abcdef...nop" in caplog.text
+
+    actual_payload = json.loads(responses.calls[0].request.body)
+    assert actual_payload["instanceId"] == instance_id
+
+
+@responses.activate
 def test_register_client_strips_trailing_slash_from_url():
     responses.add(responses.POST, FULL_REGISTER_URL, json={}, status=202)
 


### PR DESCRIPTION
## Description

Fixes three locations where `instanceId` is logged in plain text. When
`instance_id` is used as an auth token (as required by GitLab's built-in
Unleash-compatible API), these log lines expose the token in application logs.

The `Authorization` custom header (used for self-hosted Unleash auth) is
already redacted via `_redact_to_print_safely()`. This PR applies the same
protection to `instanceId` consistently across all log sites.

Changes:
- Redacts `instanceId` in `__get_identifier()` (duplicate-instance warning)
- Extracts `_redact_to_print_safely()` into `utils.py` to avoid a circular
  import from `api/register.py` and `api/metrics.py`. The class method is
  kept as a thin wrapper - no public API change.
- Redacts `instanceId` in the logged registration payload (`api/register.py`)
- Redacts `instanceId` in the logged metrics payload (`api/metrics.py`)

Wire behaviour is unchanged - the actual HTTP request bodies sent to the
server are unaffected.

Fixes # (no existing issue - discovered during integration with GitLab's Unleash API)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

New tests verify that `instanceId` does not appear in plain text in logs
for all three affected sites, and that ill present
in the actual HTTP request body sent to the server.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of
- [x] My changes generate no new warnings
- [x] I have added tests that prove my
- [x] New and existing unit tests pass locally with my changes
