### PR TITLE
EG-4662 (1): Scaffold of new `AsyncUnleashClient` + extraction of `UnleashConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * (Minor): A `fallback_function` that raises now results in `False` and a logged warning, instead of the exception propagating out of `is_enabled()`. The toggle is not counted in that case.
 * (Minor): Event callbacks are now invoked on a dedicated background thread instead of on whichever thread produced the event. `is_enabled()` and `get_variant()` no longer wait for your callback, so a slow callback can't hold up flag evaluation. Three consequences worth knowing about: callbacks can no longer read thread local state from the caller (Flask `g`, the current Django request, contextvars); they return before the callback has run, so tests asserting straight after the call now need to wait; and reassigning `unleash_event_callback` after construction is no longer honoured.
 * (Minor): Connectors take an `EventDispatcher` instead of `ready_callback`/`event_callback`. These classes aren't part of the documented API, so this only affects code importing from `UnleashClient.connectors` directly.
+* (Minor): Constructor arguments are now normalized once into an internal `UnleashConfig` object rather than being copied onto the client attribute by attribute. The public `unleash_*` attributes keep their exact values and stay writable — they now read and write through that object — so nothing in calling code needs to change. This is groundwork for an asynchronous client that shares the same configuration handling.
 
 ## v6.7.0
 * (Minor): Support for CIDR, Semver GTE and LTE constraints

--- a/UnleashClient/clients/async_unleash_client.py
+++ b/UnleashClient/clients/async_unleash_client.py
@@ -1,0 +1,83 @@
+"""
+Asynchronous Unleash client.
+
+Work in progress.  This class currently only builds the shared
+:class:`UnleashClient.config.UnleashConfig`; it performs no I/O and is not
+exported from the package root.  See ``docs/object-composition.md``.
+"""
+
+from typing import Callable, Optional
+
+from UnleashClient.cache import BaseCache
+from UnleashClient.config import ExperimentalMode, UnleashConfig
+from UnleashClient.constants import REQUEST_RETRIES, REQUEST_TIMEOUT
+from UnleashClient.events import BaseEvent
+
+_NOT_IMPLEMENTED = (
+    "AsyncUnleashClient is a work in progress and does not do anything yet. "
+    "Use UnleashClient."
+)
+
+
+class AsyncUnleashClient:
+    """An asyncio-native client for the Unleash feature toggle system."""
+
+    def __init__(  # noqa: PLR0913, PLR0917
+        self,
+        url: str,
+        app_name: str,
+        environment: str = "default",
+        instance_id: str = "unleash-python-sdk",
+        refresh_interval: int = 15,
+        refresh_jitter: Optional[int] = None,
+        metrics_interval: int = 60,
+        metrics_jitter: Optional[int] = None,
+        disable_metrics: bool = False,
+        disable_registration: bool = False,
+        custom_headers: Optional[dict] = None,
+        custom_options: Optional[dict] = None,
+        request_timeout: int = REQUEST_TIMEOUT,
+        request_retries: int = REQUEST_RETRIES,
+        custom_strategies: Optional[dict] = None,
+        cache_directory: Optional[str] = None,
+        project_name: Optional[str] = None,
+        verbose_log_level: int = 30,
+        cache: Optional[BaseCache] = None,
+        event_callback: Optional[Callable[[BaseEvent], None]] = None,
+        experimental_mode: Optional[ExperimentalMode] = None,
+        sdk_flavor: Optional[str] = None,
+        sdk_flavor_version: Optional[str] = None,
+    ) -> None:
+        self._config: UnleashConfig = UnleashConfig(
+            url=url,
+            app_name=app_name,
+            environment=environment,
+            instance_id=instance_id,
+            refresh_interval=refresh_interval,
+            refresh_jitter=refresh_jitter,
+            metrics_interval=metrics_interval,
+            metrics_jitter=metrics_jitter,
+            disable_metrics=disable_metrics,
+            disable_registration=disable_registration,
+            custom_headers=custom_headers,
+            custom_options=custom_options,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            project_name=project_name,
+            verbose_log_level=verbose_log_level,
+            sdk_flavor=sdk_flavor,
+            sdk_flavor_version=sdk_flavor_version,
+            experimental_mode=experimental_mode,
+        )
+
+    async def initialize_client(self) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def destroy(self) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def __aenter__(self) -> "AsyncUnleashClient":
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED)

--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -19,6 +19,11 @@ from yggdrasil_engine.engine import UnleashEngine
 
 from UnleashClient.api import register_client
 from UnleashClient.cache import BaseCache, FileCache
+from UnleashClient.config import (
+    ExperimentalMode,
+    UnleashConfig,
+    redact_to_print_safely,
+)
 from UnleashClient.connectors import (
     BaseConnector,
     BootstrapConnector,
@@ -50,13 +55,7 @@ from UnleashClient.utils import (
     LOGGER,
     InstanceAllowType,
     InstanceCounter,
-    extract_environment_from_headers,
 )
-
-try:
-    from typing import Literal, TypedDict
-except ImportError:
-    from typing_extensions import Literal, TypedDict  # type: ignore
 
 INSTANCES = InstanceCounter()
 _BASE_CONTEXT_FIELDS = [
@@ -74,10 +73,6 @@ class _RunState(IntEnum):
     UNINITIALIZED = 0
     INITIALIZED = 1
     SHUTDOWN = 2
-
-
-class ExperimentalMode(TypedDict, total=False):
-    type: Literal["streaming", "polling"]
 
 
 def build_ready_callback(
@@ -177,45 +172,35 @@ class UnleashClient:
         sdk_flavor: Optional[str] = None,
         sdk_flavor_version: Optional[str] = None,
     ) -> None:
-        custom_headers = custom_headers or {}
-        custom_options = custom_options or {}
         custom_strategies = custom_strategies or {}
 
-        # Configuration
-        self.unleash_url = url.rstrip("/")
-        self.unleash_app_name = app_name
-        self.unleash_environment = environment
-        self.unleash_instance_id = instance_id
-        self._connection_id = str(uuid.uuid4())
-        self.unleash_refresh_interval = refresh_interval
-        self.unleash_request_timeout = request_timeout
-        self.unleash_request_retries = request_retries
-        self.unleash_refresh_jitter = (
-            int(refresh_jitter) if refresh_jitter is not None else None
+        self._config = UnleashConfig(
+            url=url,
+            app_name=app_name,
+            environment=environment,
+            instance_id=instance_id,
+            refresh_interval=refresh_interval,
+            refresh_jitter=refresh_jitter,
+            metrics_interval=metrics_interval,
+            metrics_jitter=metrics_jitter,
+            disable_metrics=disable_metrics,
+            disable_registration=disable_registration,
+            custom_headers=custom_headers,
+            custom_options=custom_options,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            project_name=project_name,
+            verbose_log_level=verbose_log_level,
+            sdk_flavor=sdk_flavor,
+            sdk_flavor_version=sdk_flavor_version,
+            experimental_mode=experimental_mode,
         )
-        self.unleash_metrics_interval = metrics_interval
-        self.unleash_metrics_jitter = (
-            int(metrics_jitter) if metrics_jitter is not None else None
-        )
-        self.unleash_disable_metrics = disable_metrics
-        self.unleash_disable_registration = disable_registration
-        self.unleash_sdk_flavor = sdk_flavor
-        self.unleash_sdk_flavor_version = sdk_flavor_version
-        self.unleash_custom_headers = custom_headers
-        self.unleash_custom_options = custom_options
-        self.unleash_static_context = {
-            "appName": self.unleash_app_name,
-            "environment": self.unleash_environment,
-        }
-        self.unleash_project_name = project_name
-        self.unleash_verbose_log_level = verbose_log_level
         self.unleash_event_callback = event_callback
         # Events are handed to the dispatcher, which delivers them to the user's
         # callback on its own thread.  The callback is never called from here.
         self.__events: Optional[EventDispatcher] = (
             EventDispatcher(event_callback) if event_callback is not None else None
         )
-        self.connector_mode: ExperimentalMode = experimental_mode or {"type": "polling"}
         self._lifecycle_lock = threading.RLock()
         self._closed = threading.Event()
 
@@ -226,13 +211,10 @@ class UnleashClient:
         self.metric_job: Job = None
         self.engine = UnleashEngine()
 
-        impact_metrics_environment = self.unleash_environment
-        extracted_env = extract_environment_from_headers(self.unleash_custom_headers)
-        if extracted_env:
-            impact_metrics_environment = extracted_env
-
         self.impact_metrics = ImpactMetrics(
-            self.engine, self.unleash_app_name, impact_metrics_environment
+            self.engine,
+            self._config.app_name,
+            self._config.impact_metrics_environment,
         )
 
         self.cache = cache or FileCache(
@@ -291,12 +273,172 @@ class UnleashClient:
             self.unleash_scheduler = BackgroundScheduler(executors=executors)
 
     @property
+    def unleash_url(self) -> str:
+        return self._config.url
+
+    @unleash_url.setter
+    def unleash_url(self, value: str) -> None:
+        self._config.url = value
+
+    @property
+    def unleash_app_name(self) -> str:
+        return self._config.app_name
+
+    @unleash_app_name.setter
+    def unleash_app_name(self, value: str) -> None:
+        self._config.app_name = value
+
+    @property
+    def unleash_environment(self) -> str:
+        return self._config.environment
+
+    @unleash_environment.setter
+    def unleash_environment(self, value: str) -> None:
+        self._config.environment = value
+
+    @property
+    def unleash_instance_id(self) -> str:
+        return self._config.instance_id
+
+    @unleash_instance_id.setter
+    def unleash_instance_id(self, value: str) -> None:
+        self._config.instance_id = value
+
+    @property
+    def unleash_refresh_interval(self) -> int:
+        return self._config.refresh_interval
+
+    @unleash_refresh_interval.setter
+    def unleash_refresh_interval(self, value: int) -> None:
+        self._config.refresh_interval = value
+
+    @property
+    def unleash_refresh_jitter(self) -> Optional[int]:
+        return self._config.refresh_jitter
+
+    @unleash_refresh_jitter.setter
+    def unleash_refresh_jitter(self, value: Optional[int]) -> None:
+        self._config.refresh_jitter = value
+
+    @property
+    def unleash_metrics_interval(self) -> int:
+        return self._config.metrics_interval
+
+    @unleash_metrics_interval.setter
+    def unleash_metrics_interval(self, value: int) -> None:
+        self._config.metrics_interval = value
+
+    @property
+    def unleash_metrics_jitter(self) -> Optional[int]:
+        return self._config.metrics_jitter
+
+    @unleash_metrics_jitter.setter
+    def unleash_metrics_jitter(self, value: Optional[int]) -> None:
+        self._config.metrics_jitter = value
+
+    @property
+    def unleash_request_timeout(self) -> int:
+        return self._config.request_timeout
+
+    @unleash_request_timeout.setter
+    def unleash_request_timeout(self, value: int) -> None:
+        self._config.request_timeout = value
+
+    @property
+    def unleash_request_retries(self) -> int:
+        return self._config.request_retries
+
+    @unleash_request_retries.setter
+    def unleash_request_retries(self, value: int) -> None:
+        self._config.request_retries = value
+
+    @property
+    def unleash_disable_metrics(self) -> bool:
+        return self._config.disable_metrics
+
+    @unleash_disable_metrics.setter
+    def unleash_disable_metrics(self, value: bool) -> None:
+        self._config.disable_metrics = value
+
+    @property
+    def unleash_disable_registration(self) -> bool:
+        return self._config.disable_registration
+
+    @unleash_disable_registration.setter
+    def unleash_disable_registration(self, value: bool) -> None:
+        self._config.disable_registration = value
+
+    @property
+    def unleash_custom_headers(self) -> dict:
+        return self._config.custom_headers
+
+    @unleash_custom_headers.setter
+    def unleash_custom_headers(self, value: dict) -> None:
+        self._config.custom_headers = value
+
+    @property
+    def unleash_custom_options(self) -> dict:
+        return self._config.custom_options
+
+    @unleash_custom_options.setter
+    def unleash_custom_options(self, value: dict) -> None:
+        self._config.custom_options = value
+
+    @property
+    def unleash_static_context(self) -> Dict[str, Any]:
+        return self._config.static_context
+
+    @unleash_static_context.setter
+    def unleash_static_context(self, value: Dict[str, Any]) -> None:
+        self._config.static_context = value
+
+    @property
+    def unleash_project_name(self) -> Optional[str]:
+        return self._config.project_name
+
+    @unleash_project_name.setter
+    def unleash_project_name(self, value: Optional[str]) -> None:
+        self._config.project_name = value
+
+    @property
+    def unleash_verbose_log_level(self) -> int:
+        return self._config.verbose_log_level
+
+    @unleash_verbose_log_level.setter
+    def unleash_verbose_log_level(self, value: int) -> None:
+        self._config.verbose_log_level = value
+
+    @property
+    def unleash_sdk_flavor(self) -> Optional[str]:
+        return self._config.sdk_flavor
+
+    @unleash_sdk_flavor.setter
+    def unleash_sdk_flavor(self, value: Optional[str]) -> None:
+        self._config.sdk_flavor = value
+
+    @property
+    def unleash_sdk_flavor_version(self) -> Optional[str]:
+        return self._config.sdk_flavor_version
+
+    @unleash_sdk_flavor_version.setter
+    def unleash_sdk_flavor_version(self, value: Optional[str]) -> None:
+        self._config.sdk_flavor_version = value
+
+    @property
+    def connector_mode(self) -> ExperimentalMode:
+        return self._config.experimental_mode
+
+    @connector_mode.setter
+    def connector_mode(self, value: ExperimentalMode) -> None:
+        self._config.experimental_mode = value
+
+    @property
     def unleash_metrics_interval_str_millis(self) -> str:
-        return str(self.unleash_metrics_interval * 1000)
+        return self._config.metrics_interval_str_millis
 
     @property
     def connection_id(self):
-        return self._connection_id
+        return self._config.connection_id
 
     @property
     def is_initialized(self):
@@ -528,11 +670,7 @@ class UnleashClient:
 
     @staticmethod
     def _redact_to_print_safely(value: Optional[str]) -> Optional[str]:
-        if not value:
-            return value
-        prefix, separator, secret = value.rpartition(":")
-        redacted_secret = f"{secret[:6]}...{secret[-3:]}"
-        return f"{prefix}{separator}{redacted_secret}"
+        return redact_to_print_safely(value)
 
     # pylint: disable=broad-except
     def is_enabled(
@@ -661,7 +799,7 @@ class UnleashClient:
         return str(value)
 
     def _do_instance_check(self, multiple_instance_mode):
-        identifier = self.__get_identifier()
+        identifier = self._config.instance_identifier
         if identifier in INSTANCES:
             msg = f"You already have {INSTANCES.count(identifier)} instance(s) configured for this config: {identifier}, please double check the code where this client is being instantiated."
             if multiple_instance_mode == InstanceAllowType.BLOCK:
@@ -669,14 +807,6 @@ class UnleashClient:
             if multiple_instance_mode == InstanceAllowType.WARN:
                 LOGGER.error(msg)
         INSTANCES.increment(identifier)
-
-    def __get_identifier(self):
-        api_key = (
-            self.unleash_custom_headers.get("Authorization")
-            if self.unleash_custom_headers is not None
-            else None
-        )
-        return f"apiKey:{self._redact_to_print_safely(api_key)} appName:{self.unleash_app_name} instanceId:{self.unleash_instance_id}"
 
     def __enter__(self) -> "UnleashClient":
         self.initialize_client()

--- a/UnleashClient/config.py
+++ b/UnleashClient/config.py
@@ -1,0 +1,98 @@
+"""Configuration value object shared by the sync and async Unleash clients."""
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from UnleashClient.constants import REQUEST_RETRIES, REQUEST_TIMEOUT
+from UnleashClient.utils import extract_environment_from_headers
+
+try:
+    from typing import Literal, TypedDict
+except ImportError:
+    from typing_extensions import Literal, TypedDict  # type: ignore
+
+
+class ExperimentalMode(TypedDict, total=False):
+    type: Literal["streaming", "polling"]
+
+
+def redact_to_print_safely(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return value
+    prefix, separator, secret = value.rpartition(":")
+    redacted_secret = f"{secret[:6]}...{secret[-3:]}"
+    return f"{prefix}{separator}{redacted_secret}"
+
+
+@dataclass
+class UnleashConfig:
+    """
+    Normalized constructor arguments, shared by every Unleash client flavor.
+
+    Types are not validated or coerced beyond what the client constructor has
+    always done: ``url.rstrip("/")`` and ``int()`` on the two jitters.
+    """
+
+    url: str
+    app_name: str
+    environment: str = "default"
+    instance_id: str = "unleash-python-sdk"
+    refresh_interval: int = 15
+    refresh_jitter: Optional[int] = None
+    metrics_interval: int = 60
+    metrics_jitter: Optional[int] = None
+    disable_metrics: bool = False
+    disable_registration: bool = False
+    # repr=False: the dataclass __repr__ would otherwise put the Authorization
+    # API key into logs and tracebacks.
+    custom_headers: Optional[dict] = field(default=None, repr=False)
+    custom_options: Optional[dict] = None
+    request_timeout: int = REQUEST_TIMEOUT
+    request_retries: int = REQUEST_RETRIES
+    project_name: Optional[str] = None
+    verbose_log_level: int = 30
+    sdk_flavor: Optional[str] = None
+    sdk_flavor_version: Optional[str] = None
+    experimental_mode: Optional[ExperimentalMode] = None
+    connection_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    static_context: Dict[str, Any] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.url = self.url.rstrip("/")
+        self.refresh_jitter = (
+            int(self.refresh_jitter) if self.refresh_jitter is not None else None
+        )
+        self.metrics_jitter = (
+            int(self.metrics_jitter) if self.metrics_jitter is not None else None
+        )
+        # `or` rather than `is None`, so that passing {} yields a fresh dict,
+        # as the client constructor has always done.
+        self.custom_headers = self.custom_headers or {}
+        self.custom_options = self.custom_options or {}
+        self.experimental_mode = self.experimental_mode or {"type": "polling"}
+        self.static_context = {
+            "appName": self.app_name,
+            "environment": self.environment,
+        }
+
+    @property
+    def mode(self) -> str:
+        return self.experimental_mode.get("type", "polling")
+
+    @property
+    def metrics_interval_str_millis(self) -> str:
+        return str(self.metrics_interval * 1000)
+
+    @property
+    def impact_metrics_environment(self) -> str:
+        return extract_environment_from_headers(self.custom_headers) or self.environment
+
+    @property
+    def instance_identifier(self) -> str:
+        api_key = (
+            self.custom_headers.get("Authorization")
+            if self.custom_headers is not None
+            else None
+        )
+        return f"apiKey:{redact_to_print_safely(api_key)} appName:{self.app_name} instanceId:{self.instance_id}"

--- a/tests/unit_tests/clients/test_async_unleash_client.py
+++ b/tests/unit_tests/clients/test_async_unleash_client.py
@@ -1,0 +1,61 @@
+from dataclasses import asdict
+
+import pytest
+
+from tests.utilities.testing_constants import APP_NAME, URL
+from UnleashClient import INSTANCES, UnleashClient
+from UnleashClient.cache import FileCache
+from UnleashClient.clients.async_unleash_client import AsyncUnleashClient
+
+
+@pytest.fixture(autouse=True)
+def before_each():
+    INSTANCES._reset()
+
+
+def test_async_client_builds_the_shared_config():
+    client = AsyncUnleashClient("http://localhost:4242/api/", APP_NAME)
+
+    assert client._config.url == URL
+    assert client._config.app_name == APP_NAME
+    assert client._config.refresh_interval == 15
+    assert client._config.mode == "polling"
+
+
+def test_both_clients_build_the_same_config(tmpdir):
+    kwargs = dict(
+        url="http://localhost:4242/api/",
+        app_name=APP_NAME,
+        environment="unit",
+        instance_id="123",
+        refresh_interval=1,
+        refresh_jitter=2,
+        metrics_interval=3,
+        metrics_jitter=4,
+        disable_metrics=True,
+        disable_registration=True,
+        custom_headers={"Authorization": "project:environment.hash"},
+        custom_options={"verify": False},
+        request_timeout=9,
+        request_retries=2,
+        project_name="ivan",
+        verbose_log_level=40,
+        experimental_mode={"type": "streaming"},
+        sdk_flavor="openfeature",
+        sdk_flavor_version="1.2.3",
+    )
+
+    sync_client = UnleashClient(
+        cache=FileCache(APP_NAME, directory=str(tmpdir)), **kwargs
+    )
+    try:
+        async_client = AsyncUnleashClient(**kwargs)
+
+        sync_config = asdict(sync_client._config)
+        async_config = asdict(async_client._config)
+        sync_config.pop("connection_id")
+        async_config.pop("connection_id")
+
+        assert sync_config == async_config
+    finally:
+        sync_client.destroy()

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -211,6 +211,30 @@ def test_UC_type_violation():
     client.destroy()
 
 
+def test_UC_public_config_attributes_are_writable():
+    client = UnleashClient(URL, APP_NAME, disable_metrics=True)
+
+    client.unleash_refresh_interval = 99
+    client.unleash_custom_headers = {"name": "replaced"}
+    client.unleash_url = "http://elsewhere:4242/api/"
+    client.unleash_refresh_jitter = "5"
+
+    assert client.unleash_refresh_interval == 99
+    assert client.unleash_custom_headers == {"name": "replaced"}
+    assert client.unleash_url == "http://elsewhere:4242/api/"
+    assert client.unleash_refresh_jitter == "5"
+    client.destroy()
+
+
+def test_UC_custom_headers_can_be_mutated_in_place():
+    client = UnleashClient(URL, APP_NAME, custom_headers=dict(CUSTOM_HEADERS))
+
+    client.unleash_custom_headers["extra"] = "header"
+
+    assert client.unleash_custom_headers["extra"] == "header"
+    client.destroy()
+
+
 @responses.activate
 def test_uc_lifecycle(readyable_unleash_client):
     unleash_client, ready_signal, fetch_signal = readyable_unleash_client

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,0 +1,186 @@
+import uuid
+
+from UnleashClient.config import UnleashConfig
+
+URL = "http://localhost:4242/api"
+APP_NAME = "pytest"
+
+
+def test_defaults():
+    config = UnleashConfig(URL, APP_NAME)
+
+    assert config.url == URL
+    assert config.app_name == APP_NAME
+    assert config.environment == "default"
+    assert config.instance_id == "unleash-python-sdk"
+    assert config.refresh_interval == 15
+    assert config.refresh_jitter is None
+    assert config.metrics_interval == 60
+    assert config.metrics_jitter is None
+    assert config.request_timeout == 30
+    assert config.request_retries == 3
+    assert config.disable_metrics is False
+    assert config.disable_registration is False
+    assert config.custom_headers == {}
+    assert config.custom_options == {}
+    assert config.project_name is None
+    assert config.verbose_log_level == 30
+    assert config.sdk_flavor is None
+    assert config.sdk_flavor_version is None
+    assert config.experimental_mode == {"type": "polling"}
+
+
+def test_url_is_rstripped():
+    assert UnleashConfig("http://localhost:4242/api/", APP_NAME).url == URL
+    assert UnleashConfig("http://localhost:4242/api///", APP_NAME).url == URL
+    assert UnleashConfig(URL, APP_NAME).url == URL
+
+
+def test_jitters_are_int_coerced():
+    config = UnleashConfig(URL, APP_NAME, refresh_jitter=5.9, metrics_jitter="7")
+
+    assert config.refresh_jitter == 5
+    assert config.metrics_jitter == 7
+
+
+def test_zero_jitter_is_preserved_and_not_confused_with_none():
+    config = UnleashConfig(URL, APP_NAME, refresh_jitter=0, metrics_jitter=0)
+
+    assert config.refresh_jitter == 0
+    assert config.metrics_jitter == 0
+    assert UnleashConfig(URL, APP_NAME).refresh_jitter is None
+
+
+def test_no_other_coercion():
+    # The client has never validated these, and UnleashClient exposes them
+    # verbatim.  See test_UC_type_violation.
+    config = UnleashConfig(
+        URL, APP_NAME, refresh_interval="60", metrics_interval="60", request_timeout="9"
+    )
+
+    assert config.refresh_interval == "60"
+    assert config.metrics_interval == "60"
+    assert config.request_timeout == "9"
+
+
+def test_connection_id_is_generated_and_unique():
+    first = UnleashConfig(URL, APP_NAME)
+    second = UnleashConfig(URL, APP_NAME)
+
+    uuid.UUID(first.connection_id)
+    assert first.connection_id != second.connection_id
+
+
+def test_connection_id_can_be_supplied():
+    config = UnleashConfig(URL, APP_NAME, connection_id="fixed-id")
+
+    assert config.connection_id == "fixed-id"
+
+
+def test_static_context():
+    config = UnleashConfig(URL, APP_NAME, environment="unit")
+
+    assert config.static_context == {"appName": APP_NAME, "environment": "unit"}
+    assert config.static_context is config.static_context
+
+    config.static_context["environment"] = "qa"
+    assert config.static_context["environment"] == "qa"
+
+
+def test_custom_headers_are_not_copied():
+    headers = {"Authorization": "project:environment.hash"}
+    config = UnleashConfig(URL, APP_NAME, custom_headers=headers)
+
+    assert config.custom_headers is headers
+
+
+def test_empty_custom_dicts_become_fresh_dicts():
+    headers: dict = {}
+    options: dict = {}
+    config = UnleashConfig(
+        URL, APP_NAME, custom_headers=headers, custom_options=options
+    )
+
+    assert config.custom_headers is not headers
+    assert config.custom_options is not options
+
+
+def test_metrics_interval_str_millis():
+    assert UnleashConfig(URL, APP_NAME).metrics_interval_str_millis == "60000"
+    assert (
+        UnleashConfig(URL, APP_NAME, metrics_interval=2).metrics_interval_str_millis
+        == "2000"
+    )
+
+
+def test_impact_metrics_environment_defaults_to_environment():
+    config = UnleashConfig(URL, APP_NAME, environment="unit")
+
+    assert config.impact_metrics_environment == "unit"
+
+
+def test_impact_metrics_environment_is_taken_from_the_api_token():
+    config = UnleashConfig(
+        URL,
+        APP_NAME,
+        environment="unit",
+        custom_headers={"Authorization": "project:production.hash"},
+    )
+
+    assert config.impact_metrics_environment == "production"
+
+
+def test_impact_metrics_environment_falls_back_on_an_unparseable_token():
+    config = UnleashConfig(
+        URL,
+        APP_NAME,
+        environment="unit",
+        custom_headers={"Authorization": "no-colon-here"},
+    )
+
+    assert config.impact_metrics_environment == "unit"
+
+
+def test_instance_identifier_redacts_the_api_key():
+    config = UnleashConfig(
+        URL,
+        APP_NAME,
+        instance_id="123",
+        custom_headers={"Authorization": "project:environment.abcdefghijklmnop"},
+    )
+
+    identifier = config.instance_identifier
+
+    assert "abcdefghijklmnop" not in identifier
+    # rpartition splits on the last colon, so everything after "project:" is
+    # treated as the secret.
+    assert identifier == ("apiKey:project:enviro...nop appName:pytest instanceId:123")
+
+
+def test_instance_identifier_without_headers():
+    config = UnleashConfig(URL, APP_NAME, instance_id="123")
+
+    assert config.instance_identifier == ("apiKey:None appName:pytest instanceId:123")
+
+
+def test_experimental_mode_is_passed_through():
+    mode = {"type": "streaming", "somethingElse": True}
+    config = UnleashConfig(URL, APP_NAME, experimental_mode=mode)
+
+    assert config.experimental_mode is mode
+    assert config.mode == "streaming"
+
+
+def test_mode_defaults_to_polling():
+    assert UnleashConfig(URL, APP_NAME).mode == "polling"
+    assert UnleashConfig(URL, APP_NAME, experimental_mode={}).mode == "polling"
+
+
+def test_repr_does_not_leak_the_api_key():
+    config = UnleashConfig(
+        URL,
+        APP_NAME,
+        custom_headers={"Authorization": "project:environment.abcdefghijklmnop"},
+    )
+
+    assert "abcdefghijklmnop" not in repr(config)


### PR DESCRIPTION
## Quick summary

---

> [!NOTE]
> This being the first PR of the stack, the summary won't be as quick as in the ones to follow. Here I lay out the idea behind the stack of PRs to come.

The previous stacked focused on threaded work to pull event callbacks out of the hot path. This on is directly concerned with the implementation of AsyncUnleashClient by reusing as much code as possible.

`UnleashClient` was doing too many things. Moving them to an `ABC` that both clients shared would make things worse in the future and, because one had to be sync and the other did not, it made sharing code very hard. So, instead of inheritance I've leaned on _composition_: I've broken down each responsibility into a separate class and then used that new class in both flavors of client (`UnleashClient` and `AsyncUnleashClient`).

I'm still working on the classes that cannot be shared between sync and async implementations (aka the colored classes).

At the moment, `UnleashClient` is a single class holding fifteen responsibilities:

1. Constructor argument normalization and validation.
2. Client identity: connection id, app name, instance id, header assembly.
3. Duplicate-instance detection against a module-global counter.
4. Ownership of the Yggdrasil engine and flag evaluation.
5. Context enrichment and sanitization.
6. Impression event construction.
7. Cache ownership and seeding.
8. Bootstrap from cache.
9. Registration with the Unleash server.
10. Feature provisioning strategy selection.
11. Job scheduling via APScheduler.
12. The metrics send loop and the shutdown flush.
13. Impact metrics wiring.
14. Run-state machine, locking, and shutdown ordering.
15. HTTP concerns: `custom_options`, timeouts, retries.

Our goal is to extract them one by one (more or less, some like shutdown ordering do make sense in the parent class) into separate objects that have a single responsibility. Once a responsibility is out of `UnleashClient` and into another object (e.g. `UnleashConfig`), that new object can be shared between the two flavors of the client.

---

### This PR

In this pull request, I have extracted all the values of `UnleashClient` that configure the behavior of the SDK and moved them to a new `UnleashConfig` class.

That class is then a collaborator that both the `UnleashClient` and the `AsyncUnleashClient` can share.

I have then scaffolded the `AsyncUnleashClient` class, which does nothing at this point.

## Related context

Contributes to https://github.com/Unleash/unleash-python-sdk/issues/240

## What to focus on

This PR is rather simple, I'd pay attention to not having forgotten any configuration value in the process.

## How to Verify / Test

- `make test` should pass

## Risks & Operational Notes

- [ ] We have not lost any configuration value that users could use to configure their SDK.