### PR TITLE
EG-4662 (2): Extract `ContextEnricher`

### DIFF
--- a/UnleashClient/clients/async_unleash_client.py
+++ b/UnleashClient/clients/async_unleash_client.py
@@ -1,9 +1,10 @@
 """
 Asynchronous Unleash client.
 
-Work in progress.  This class currently only builds the shared
-:class:`UnleashClient.config.UnleashConfig`; it performs no I/O and is not
-exported from the package root.  See ``docs/object-composition.md``.
+Work in progress.  This class currently only builds the collaborators it
+shares with :class:`UnleashClient.clients.unleash_client.UnleashClient`; it
+performs no I/O and is not exported from the package root.  See
+``docs/object-composition.md``.
 """
 
 from typing import Callable, Optional
@@ -11,6 +12,7 @@ from typing import Callable, Optional
 from UnleashClient.cache import BaseCache
 from UnleashClient.config import ExperimentalMode, UnleashConfig
 from UnleashClient.constants import REQUEST_RETRIES, REQUEST_TIMEOUT
+from UnleashClient.context import ContextEnricher
 from UnleashClient.events import BaseEvent
 
 _NOT_IMPLEMENTED = (
@@ -69,6 +71,7 @@ class AsyncUnleashClient:
             sdk_flavor_version=sdk_flavor_version,
             experimental_mode=experimental_mode,
         )
+        self._enricher = ContextEnricher(self._config)
 
     async def initialize_client(self) -> None:
         raise NotImplementedError(_NOT_IMPLEMENTED)

--- a/UnleashClient/clients/unleash_client.py
+++ b/UnleashClient/clients/unleash_client.py
@@ -40,6 +40,7 @@ from UnleashClient.constants import (
     SDK_NAME,
     SDK_VERSION,
 )
+from UnleashClient.context import ContextEnricher
 from UnleashClient.events import (
     BaseEvent,
     EventDispatcher,
@@ -58,15 +59,6 @@ from UnleashClient.utils import (
 )
 
 INSTANCES = InstanceCounter()
-_BASE_CONTEXT_FIELDS = [
-    "userId",
-    "sessionId",
-    "environment",
-    "appName",
-    "currentTime",
-    "remoteAddress",
-    "properties",
-]
 
 
 class _RunState(IntEnum):
@@ -195,6 +187,7 @@ class UnleashClient:
             sdk_flavor_version=sdk_flavor_version,
             experimental_mode=experimental_mode,
         )
+        self._enricher = ContextEnricher(self._config)
         self.unleash_event_callback = event_callback
         # Events are handed to the dispatcher, which delivers them to the user's
         # callback on its own thread.  The callback is never called from here.
@@ -691,7 +684,7 @@ class UnleashClient:
         :param fallback_function: Allows users to provide a custom function to set default value.
         :return: Feature flag result
         """
-        context = self._safe_context(context)
+        context = self._enricher.build(context)
         result = self.engine.is_enabled(
             feature_name, context, fallback_function=fallback_function
         )
@@ -729,7 +722,7 @@ class UnleashClient:
         :param context: Dictionary with context (e.g. IPs, email) for feature toggle.
         :return: Variant and feature flag status.
         """
-        context = self._safe_context(context)
+        context = self._enricher.build(context)
         result = self.engine.get_variant(feature_name, context)
 
         if not result.is_found and (self.unleash_bootstrapped or self.is_initialized):
@@ -761,42 +754,6 @@ class UnleashClient:
         # This can probably become a to_dict method of the Variant type.
         variant = {k: v for k, v in asdict(result.variant).items() if v is not None}
         return variant
-
-    def _safe_context(self, context) -> dict:
-        new_context: Dict[str, Any] = self.unleash_static_context.copy()
-        new_context.update(context or {})
-
-        if "currentTime" not in new_context:
-            new_context["currentTime"] = datetime.now(timezone.utc).isoformat()
-
-        safe_properties = self._extract_properties(new_context)
-        safe_properties = {
-            k: self._safe_context_value(v) for k, v in safe_properties.items()
-        }
-        safe_context = {
-            k: self._safe_context_value(v)
-            for k, v in new_context.items()
-            if k != "properties"
-        }
-
-        safe_context["properties"] = safe_properties
-
-        return safe_context
-
-    def _extract_properties(self, context: dict) -> dict:
-        properties = context.get("properties", {})
-        extracted_fields = {
-            k: v for k, v in context.items() if k not in _BASE_CONTEXT_FIELDS
-        }
-        extracted_fields.update(properties)
-        return extracted_fields
-
-    def _safe_context_value(self, value):
-        if isinstance(value, datetime):
-            return value.isoformat()
-        if isinstance(value, (int, float)):
-            return str(value)
-        return str(value)
 
     def _do_instance_check(self, multiple_instance_mode):
         identifier = self._config.instance_identifier

--- a/UnleashClient/context.py
+++ b/UnleashClient/context.py
@@ -1,0 +1,60 @@
+"""Evaluation context enrichment, shared by the sync and async Unleash clients."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from UnleashClient.config import UnleashConfig
+
+BASE_CONTEXT_FIELDS = [
+    "userId",
+    "sessionId",
+    "environment",
+    "appName",
+    "currentTime",
+    "remoteAddress",
+    "properties",
+]
+
+
+def _safe_value(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+class ContextEnricher:
+    """
+    Turns a caller-supplied context into the shape the engine expects.
+
+    The config's static context is read on every call, so reassigning
+    ``config.static_context`` (which ``UnleashClient.unleash_static_context``
+    does) takes effect immediately.
+    """
+
+    def __init__(self, config: UnleashConfig) -> None:
+        self._config: UnleashConfig = config
+
+    def build(self, context: Optional[dict] = None) -> dict:
+        new_context: Dict[str, Any] = self._config.static_context.copy()
+        new_context.update(context or {})
+
+        if "currentTime" not in new_context:
+            new_context["currentTime"] = datetime.now(timezone.utc).isoformat()
+
+        safe_properties = self._extract_properties(new_context)
+        safe_properties = {k: _safe_value(v) for k, v in safe_properties.items()}
+        safe_context: Dict[str, Any] = {
+            k: _safe_value(v) for k, v in new_context.items() if k != "properties"
+        }
+
+        safe_context["properties"] = safe_properties
+
+        return safe_context
+
+    def _extract_properties(self, context: dict) -> dict:
+        properties = context.get("properties", {})
+        extracted_fields = {
+            k: v for k, v in context.items() if k not in BASE_CONTEXT_FIELDS
+        }
+        extracted_fields.update(properties)
+        return extracted_fields

--- a/tests/unit_tests/clients/test_async_unleash_client.py
+++ b/tests/unit_tests/clients/test_async_unleash_client.py
@@ -59,3 +59,38 @@ def test_both_clients_build_the_same_config(tmpdir):
         assert sync_config == async_config
     finally:
         sync_client.destroy()
+
+
+def test_async_client_enriches_context_over_its_own_config():
+    client = AsyncUnleashClient(URL, APP_NAME, environment="unit")
+
+    context = client._enricher.build({"myContext": "1234"})
+
+    assert context["appName"] == APP_NAME
+    assert context["environment"] == "unit"
+    assert context["properties"]["myContext"] == "1234"
+
+
+def test_both_clients_enrich_context_identically(tmpdir):
+    kwargs = dict(url=URL, app_name=APP_NAME, environment="unit")
+    # currentTime is supplied so the two clients don't each generate their own.
+    context = {
+        "userId": 7,
+        "myContext": "1234",
+        "currentTime": "1834-02-20T00:00:00+00:00",
+    }
+
+    sync_client = UnleashClient(
+        cache=FileCache(APP_NAME, directory=str(tmpdir)),
+        disable_metrics=True,
+        disable_registration=True,
+        **kwargs,
+    )
+    try:
+        async_client = AsyncUnleashClient(**kwargs)
+
+        assert sync_client._enricher.build(context) == async_client._enricher.build(
+            context
+        )
+    finally:
+        sync_client.destroy()

--- a/tests/unit_tests/clients/test_unleash_client.py
+++ b/tests/unit_tests/clients/test_unleash_client.py
@@ -1376,49 +1376,6 @@ def test_context_adds_current_time_if_not_set():
     unleash_client.destroy()
 
 
-def test_context_moves_properties_fields_to_properties():
-    unleash_client = UnleashClient(
-        URL,
-        APP_NAME,
-        disable_metrics=True,
-        disable_registration=True,
-    )
-
-    context = {"myContext": "1234"}
-
-    assert "myContext" in unleash_client._safe_context(context)["properties"]
-    unleash_client.destroy()
-
-
-def test_existing_properties_are_retained_when_custom_context_properties_are_in_the_root():
-    unleash_client = UnleashClient(
-        URL,
-        APP_NAME,
-        disable_metrics=True,
-        disable_registration=True,
-    )
-
-    context = {"myContext": "1234", "properties": {"yourContext": "1234"}}
-
-    assert "myContext" in unleash_client._safe_context(context)["properties"]
-    assert "yourContext" in unleash_client._safe_context(context)["properties"]
-    unleash_client.destroy()
-
-
-def test_base_context_properties_are_retained_in_root():
-    unleash_client = UnleashClient(
-        URL,
-        APP_NAME,
-        disable_metrics=True,
-        disable_registration=True,
-    )
-
-    context = {"userId": "1234"}
-
-    assert "userId" in unleash_client._safe_context(context)
-    unleash_client.destroy()
-
-
 def test_is_enabled_works_with_properties_field_in_the_context_root():
     cache = FileCache("MOCK_CACHE")
     cache.bootstrap_from_dict(MOCK_FEATURE_WITH_CUSTOM_CONTEXT_REQUIREMENTS)

--- a/tests/unit_tests/test_context.py
+++ b/tests/unit_tests/test_context.py
@@ -1,0 +1,127 @@
+import uuid
+from datetime import datetime, timezone
+
+from UnleashClient.config import UnleashConfig
+from UnleashClient.context import ContextEnricher
+
+URL = "http://localhost:4242/api"
+APP_NAME = "pytest"
+
+
+def build_enricher(**kwargs) -> ContextEnricher:
+    return ContextEnricher(UnleashConfig(URL, APP_NAME, **kwargs))
+
+
+def test_static_context_is_merged_in():
+    enricher = build_enricher(environment="unit")
+
+    context = enricher.build({})
+
+    assert context["appName"] == APP_NAME
+    assert context["environment"] == "unit"
+
+
+def test_caller_overrides_the_static_context():
+    enricher = build_enricher(environment="unit")
+
+    context = enricher.build({"environment": "qa", "appName": "other"})
+
+    assert context["environment"] == "qa"
+    assert context["appName"] == "other"
+
+
+def test_no_context_at_all():
+    enricher = build_enricher()
+
+    context = enricher.build(None)
+
+    assert context["appName"] == APP_NAME
+    assert "currentTime" in context
+    assert context["properties"] == {}
+
+
+def test_base_context_properties_are_retained_in_root():
+    enricher = build_enricher()
+
+    context = enricher.build({"userId": "1234"})
+
+    assert "userId" in context
+
+
+def test_context_moves_properties_fields_to_properties():
+    enricher = build_enricher()
+
+    context = enricher.build({"myContext": "1234"})
+
+    assert "myContext" in context["properties"]
+
+
+def test_existing_properties_are_retained_when_custom_context_properties_are_in_the_root():
+    enricher = build_enricher()
+
+    context = enricher.build(
+        {"myContext": "1234", "properties": {"yourContext": "1234"}}
+    )
+
+    assert "myContext" in context["properties"]
+    assert "yourContext" in context["properties"]
+
+
+def test_properties_win_over_the_root_on_a_name_clash():
+    enricher = build_enricher()
+
+    context = enricher.build(
+        {"myContext": "root", "properties": {"myContext": "nested"}}
+    )
+
+    assert context["properties"]["myContext"] == "nested"
+
+
+def test_current_time_is_added_when_missing():
+    enricher = build_enricher()
+
+    context = enricher.build({})
+
+    assert datetime.fromisoformat(context["currentTime"]).tzinfo is timezone.utc
+
+
+def test_a_supplied_current_time_is_kept_and_isoformatted():
+    enricher = build_enricher()
+    current_time = datetime.fromisoformat("1834-02-20").replace(tzinfo=timezone.utc)
+
+    context = enricher.build({"currentTime": current_time})
+
+    assert context["currentTime"] == current_time.isoformat()
+
+
+def test_values_are_stringified():
+    enricher = build_enricher()
+    identifier = uuid.uuid4()
+
+    context = enricher.build({"userId": 99999, "score": 1.5, "traceId": identifier})
+
+    assert context["userId"] == "99999"
+    assert context["properties"]["score"] == "1.5"
+    assert context["properties"]["traceId"] == str(identifier)
+
+
+def test_the_supplied_context_is_not_mutated():
+    enricher = build_enricher()
+    original = {"myContext": "1234"}
+
+    enricher.build(original)
+
+    assert original == {"myContext": "1234"}
+
+
+def test_static_context_is_read_on_every_call():
+    # UnleashClient.unleash_static_context has a setter, so a client can swap
+    # the dict out after the enricher was constructed.
+    config = UnleashConfig(URL, APP_NAME, environment="unit")
+    enricher = ContextEnricher(config)
+
+    config.static_context = {"appName": "replaced", "environment": "qa"}
+    context = enricher.build({})
+
+    assert context["appName"] == "replaced"
+    assert context["environment"] == "qa"


### PR DESCRIPTION
## Quick summary

This PR moves the building of the context to a `ContextEnricher` class and turns it into a collaborator that both the `UnleashClient` and its async homonymous share.

## Related Context

Contributes to https://github.com/Unleash/unleash-python-sdk/issues/240

## Approach

Until now, `UnleashClient` would deal with grabbing the context from the user (a plain `dict` with arbitrary key value pairs) and reshaping it into the context that the unleash servers expect: a dictionary with the keys: `"userId", "sessionId", "environment", "appName", "currentTime", "remoteAddress", "properties"` at its first level, and the context from the user relegated to the `properties` map.

This logic has been moved to its own class and it is now shared between the two clients.

## Where to focus the review

- `UnleashClient/context.py` must return the context in the same shape that existed before.

## How to Verify

- `make test` should pass

## Risks & Operational Notes

- [ ] This PR moves the logic that builds the context. Breaking it renders the SDK unusable.