### PR TITLE
EG-4662 (8.5): Introduce new `AsyncTransport`

### DIFF
--- a/UnleashClient/async_transport.py
+++ b/UnleashClient/async_transport.py
@@ -1,0 +1,292 @@
+"""Asynchronous HTTP transport, for the async Unleash client."""
+
+import asyncio
+import json
+from typing import Any, Dict, Optional
+
+from multidict import CIMultiDict
+
+from UnleashClient.config import UnleashConfig
+from UnleashClient.constants import FEATURES_URL, METRICS_URL, REGISTER_URL
+from UnleashClient.headers import HeaderFactory
+from UnleashClient.transport import FetchResult, normalized_url
+from UnleashClient.utils import LOGGER
+
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "AsyncUnleashClient requires aiohttp, which is not installed. "
+        "Install it with: pip install UnleashClient[async]"
+    ) from exc
+
+
+# The statuses urllib3's Retry is given in Transport.fetch_features.
+RETRY_STATUSES = frozenset({500, 502, 504})
+
+# What a retry is worth attempting for. Deliberately narrower than
+# aiohttp.ClientError: InvalidUrlClientError and NonHttpUrlClientError also
+# subclass it, and a malformed url is not going to fix itself on attempt two.
+RETRYABLE_ERRORS = (aiohttp.ClientConnectionError, asyncio.TimeoutError)
+
+# The two aiohttp raises for a url it cannot use at all -- the analogue of the
+# requests quartet Transport.register re-raises. Both subclass ClientError, so
+# they have to be caught ahead of it. aiohttp has no InvalidHeader: an illegal
+# header surfaces as a bare ValueError, which is not a ClientError and so
+# escapes register() without a clause of its own.
+FATAL_URL_ERRORS = (aiohttp.InvalidURL, aiohttp.NonHttpUrlClientError)
+
+
+async def _log_resp_info(resp: "aiohttp.ClientResponse") -> None:
+    LOGGER.debug("HTTP status code: %s", resp.status)
+    LOGGER.debug("HTTP headers: %s", resp.headers)
+    LOGGER.debug("HTTP content: %s", await resp.text())
+
+
+class AsyncTransport:
+    """
+    The asyncio twin of :class:`UnleashClient.transport.Transport`, and the
+    async half of the one colored leaf in the SDK.
+
+    It matches ``Transport`` method for method and returns the same
+    :class:`~UnleashClient.transport.FetchResult`, so everything downstream of a
+    request -- :class:`~UnleashClient.store.FeatureStore`, the payload builders,
+    the :class:`~UnleashClient.headers.HeaderFactory` -- is shared rather than
+    duplicated. ``aclose()`` is the one method with no sync counterpart.
+
+    Like ``Transport``, it reads the config and asks the header factory on every
+    request rather than capturing either, because the ``unleash_*`` properties
+    that back them are public and writable.
+
+    Two things differ from the sync class, both forced by aiohttp:
+
+    - ``custom_options`` are ``requests`` keyword arguments and do not transfer.
+      ``verify``, ``cert`` and ``proxies`` all raise ``TypeError`` here; the
+      aiohttp spellings are ``ssl`` and ``proxy``.
+    - One pooled ``ClientSession`` is held rather than a session per request,
+      and it is built on first use, not in ``__init__`` -- aiohttp resolves the
+      running loop eagerly, and ``AsyncUnleashClient.__init__`` is synchronous.
+      That binds a transport to whichever loop first used it, and makes
+      ``aclose()`` an obligation on the caller.
+    """
+
+    def __init__(self, config: UnleashConfig, headers: HeaderFactory) -> None:
+        """
+        :param config: read for the url, timeouts, retries, project and custom
+                       options.
+        :param headers: builds the header set each request needs.
+        """
+        self._config: UnleashConfig = config
+        self._headers: HeaderFactory = headers
+        self._session: Optional["aiohttp.ClientSession"] = None
+
+    async def _get_session(self) -> "aiohttp.ClientSession":
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    def _timeout(self) -> "aiohttp.ClientTimeout":
+        # sock_connect/sock_read rather than total, because requests' scalar
+        # timeout bounds each socket operation and not the whole request. Under
+        # `total` a large feature payload over a slow but healthy link would
+        # start failing at a request_timeout that works today.
+        seconds = self._config.request_timeout
+        return aiohttp.ClientTimeout(
+            total=None, sock_connect=seconds, sock_read=seconds
+        )
+
+    async def aclose(self) -> None:
+        """
+        Close the pooled session, if one was ever opened.
+
+        Nothing calls this yet -- ``AsyncUnleashClient.destroy()`` is still
+        unimplemented, and closing is its job when it lands. Until then every
+        caller that makes a request owns the close, or aiohttp logs an unclosed
+        session on garbage collection.
+        """
+        session, self._session = self._session, None
+        if session is not None and not session.closed:
+            await session.close()
+
+    # pylint: disable=broad-except
+    # TODO: narrow the except clause to the same set of errors the sync transport
+    # so TransportError becomes part of the API of transports.
+    async def fetch_features(self, etag: str = "") -> FetchResult:
+        """
+        Fetch feature state, sending ``If-None-Match`` when an etag is known.
+
+        Never raises. Any failure -- an unexpected status, a connection error, a
+        bad key in ``custom_options`` -- is logged and returned as an empty
+        result, so a polling job can keep running against a server that is down.
+
+        :param etag: the cached etag, or "" to fetch unconditionally.
+        """
+        config = self._config
+        try:
+            LOGGER.info("Getting feature flag.")
+
+            # A CIMultiDict rather than a dict: the uppercase pair below
+            # collides with the lowercase one HeaderFactory.base() already
+            # carries, and aiohttp would put *both* spellings on the wire where
+            # requests folds them into one. Updating a CIMultiDict replaces,
+            # which is the behaviour the sync transport has always had.
+            headers = CIMultiDict(self._headers.polling())
+
+            # The features endpoint has always been sent an uppercase copy of
+            # the two identification headers. It stays here rather than in
+            # polling() because it is a quirk of this one endpoint.
+            headers.update(
+                {
+                    "UNLEASH-APPNAME": config.app_name,
+                    "UNLEASH-INSTANCEID": config.instance_id,
+                }
+            )
+
+            if etag:
+                headers["If-None-Match"] = etag
+
+            base_url = normalized_url(config.url, FEATURES_URL)
+            base_params = {}
+
+            if config.project_name:
+                base_params = {"project": config.project_name}
+
+            session = await self._get_session()
+            # aiohttp has no equivalent of the HTTPAdapter/Retry the sync
+            # transport mounts, so the loop is here. urllib3's Retry defaults to
+            # backoff_factor=0, so neither path sleeps between attempts.
+            attempts = 1 + max(config.request_retries, 0)
+
+            for attempt in range(attempts):
+                last_attempt = attempt == attempts - 1
+                try:
+                    async with session.get(
+                        base_url,
+                        headers=headers,
+                        params=base_params,
+                        timeout=self._timeout(),
+                        **config.custom_options,
+                    ) as resp:
+                        if resp.status in RETRY_STATUSES and not last_attempt:
+                            continue
+
+                        if resp.status not in [200, 304]:
+                            await _log_resp_info(resp)
+                            LOGGER.warning(
+                                "Unleash Client feature fetch failed due to unexpected HTTP status code: %s",
+                                resp.status,
+                            )
+                            raise Exception(  # pylint: disable=broad-exception-raised
+                                "Unleash Client feature fetch failed!"
+                            )
+
+                        fetched_etag = resp.headers.get("etag", "")
+
+                        if resp.status == 304:
+                            return FetchResult(None, fetched_etag, not_modified=True)
+
+                        return FetchResult(await resp.text(), fetched_etag)
+                except RETRYABLE_ERRORS:
+                    if last_attempt:
+                        raise
+        except Exception as exc:
+            LOGGER.exception(
+                "Unleash Client feature fetch failed due to exception: %s", exc
+            )
+
+        return FetchResult(None, "")
+
+    async def register(self, payload: Dict[str, Any]) -> bool:
+        """
+        Register this client with the server.
+
+        Returns True on 200 or 202, False on any other status and on a general
+        ``ClientError``. Re-raises the two errors aiohttp uses for a url it
+        cannot make a request against at all, which is what makes
+        ``initialize_client()`` fail loudly on a malformed URL instead of
+        starting a client that can never reach the server.
+
+        :param payload: as built by
+                        :func:`UnleashClient.payloads.build_register_payload`.
+        """
+        config = self._config
+        try:
+            LOGGER.info("Registering unleash client with unleash @ %s", config.url)
+            LOGGER.info("Registration request information: %s", payload)
+
+            session = await self._get_session()
+            # No retry loop, matching the sync register: only fetch_features
+            # mounts the retry adapter.
+            async with session.post(
+                normalized_url(config.url, REGISTER_URL),
+                data=json.dumps(payload),
+                headers=self._headers.base(),
+                timeout=self._timeout(),
+                **config.custom_options,
+            ) as resp:
+                if resp.status not in {200, 202}:
+                    await _log_resp_info(resp)
+                    LOGGER.warning(
+                        "Unleash Client registration failed due to unexpected HTTP status code: %s",
+                        resp.status,
+                    )
+                    return False
+
+                LOGGER.info("Unleash Client successfully registered!")
+
+                return True
+        # Ahead of the ClientError clause below: both subclass it, and Python
+        # matches the first clause that fits.
+        except FATAL_URL_ERRORS as exc:
+            LOGGER.exception(
+                "Unleash Client registration failed fatally due to exception: %s", exc
+            )
+            raise exc
+        except aiohttp.ClientError as exc:
+            LOGGER.exception(
+                "Unleash Client registration failed due to exception: %s", exc
+            )
+
+        return False
+
+    async def send_metrics(self, payload: Dict[str, Any]) -> bool:
+        """
+        Send one metrics bucket.
+
+        Returns True only on 202; every other status is a failure, which is what
+        the caller's impact-metrics restore path keys off. Catches only
+        ``ClientError``, so a bad key in ``custom_options`` still surfaces as a
+        ``TypeError`` to the caller rather than being reported as a failed send.
+
+        :param payload: the metrics request body.
+        """
+        config = self._config
+        try:
+            LOGGER.info("Sending messages to with unleash @ %s", config.url)
+            LOGGER.info("unleash metrics information: %s", payload)
+
+            session = await self._get_session()
+            async with session.post(
+                normalized_url(config.url, METRICS_URL),
+                data=json.dumps(payload),
+                headers=self._headers.metrics(),
+                timeout=self._timeout(),
+                **config.custom_options,
+            ) as resp:
+                if resp.status != 202:
+                    await _log_resp_info(resp)
+                    LOGGER.warning(
+                        "Unleash Client metrics submission due to unexpected HTTP status code: %s",
+                        resp.status,
+                    )
+                    return False
+
+                LOGGER.info("Unleash Client metrics successfully sent!")
+
+                return True
+        except aiohttp.ClientError as exc:
+            LOGGER.warning(
+                "Unleash Client metrics submission failed due to exception: %s", exc
+            )
+
+        return False

--- a/UnleashClient/clients/async_unleash_client.py
+++ b/UnleashClient/clients/async_unleash_client.py
@@ -1,16 +1,22 @@
 """
 Asynchronous Unleash client.
 
-Work in progress.  This class currently only builds the collaborators it
-shares with :class:`UnleashClient.clients.unleash_client.UnleashClient`; it
-performs no network I/O and is not exported from the package root.  See
+Work in progress.  This class builds the collaborators it shares with
+:class:`UnleashClient.clients.unleash_client.UnleashClient`, plus its own
+:class:`~UnleashClient.async_transport.AsyncTransport`.  Nothing calls that
+transport yet, so constructing the client still performs no I/O and opens no
+session, and the class is not exported from the package root.  See
 ``docs/object-composition.md``.
+
+Importing this module requires the optional ``aiohttp`` dependency:
+``pip install UnleashClient[async]``.
 """
 
 from typing import Callable, Optional
 
 from yggdrasil_engine.engine import UnleashEngine
 
+from UnleashClient.async_transport import AsyncTransport
 from UnleashClient.cache import BaseCache, FileCache
 from UnleashClient.config import ExperimentalMode, UnleashConfig
 from UnleashClient.constants import REQUEST_RETRIES, REQUEST_TIMEOUT
@@ -89,6 +95,7 @@ class AsyncUnleashClient:
         self._store: FeatureStore = FeatureStore(
             engine=self._engine, cache=self._cache, events=self._event_dispatcher
         )
+        self._transport: AsyncTransport = AsyncTransport(self._config, self._headers)
         self._scheduler: Scheduler = Scheduler()
 
     async def initialize_client(self) -> None:

--- a/UnleashClient/transport.py
+++ b/UnleashClient/transport.py
@@ -27,7 +27,7 @@ class FetchResult(NamedTuple):
     not_modified: bool = False
 
 
-def _normalized_url(url: str, path: str) -> str:
+def normalized_url(url: str, path: str) -> str:
     # config.url can carry a trailing slash: the UnleashClient.unleash_url setter
     # writes it without re-normalizing.
     return f"{url.rstrip('/')}{path}"
@@ -79,7 +79,7 @@ class Transport:
             if etag:
                 request_specific_headers["If-None-Match"] = etag
 
-            base_url = _normalized_url(config.url, FEATURES_URL)
+            base_url = normalized_url(config.url, FEATURES_URL)
             base_params = {}
 
             if config.project_name:
@@ -145,7 +145,7 @@ class Transport:
             LOGGER.info("Registration request information: %s", payload)
 
             resp = requests.post(
-                _normalized_url(config.url, REGISTER_URL),
+                normalized_url(config.url, REGISTER_URL),
                 data=json.dumps(payload),
                 headers=self._headers.base(),
                 timeout=config.request_timeout,
@@ -188,7 +188,7 @@ class Transport:
             LOGGER.info("unleash metrics information: %s", payload)
 
             resp = requests.post(
-                _normalized_url(config.url, METRICS_URL),
+                normalized_url(config.url, METRICS_URL),
                 data=json.dumps(payload),
                 headers=self._headers.metrics(),
                 timeout=config.request_timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dependencies=[
     "launchdarkly-eventsource",
 ]
 
+[project.optional-dependencies]
+# Required by the in-progress AsyncUnleashClient only.  3.9 is the floor because
+# it introduced InvalidUrlClientError/NonHttpUrlClientError, which
+# AsyncTransport.register re-raises.
+async = ["aiohttp >= 3.9"]
+
 [project.urls]
 Homepage = "https://github.com/Unleash/unleash-python-sdk"
 Documentation = "https://docs.getunleash.io/unleash-python-sdk"
@@ -61,6 +67,7 @@ addopts= """
     --disable-warnings
 """
 log_file_level="INFO"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 lint.select = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ requests
 semver
 yggdrasil-engine==2.0.0a1
 launchdarkly-eventsource
+aiohttp
 
 # Development packages
 # - Testing
@@ -21,8 +22,11 @@ pytest
 pytest-cov
 pytest-html
 pytest-mock
+pytest-asyncio
 pytest-xdist
 responses
+# 0.7.9 is py3.9+: it annotates with a bare `Mapping[str, str]` at import time.
+aioresponses < 0.7.9
 ruff
 tox
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,6 @@ pytest-mock
 pytest-asyncio
 pytest-xdist
 responses
-# 0.7.9 is py3.9+: it annotates with a bare `Mapping[str, str]` at import time.
-aioresponses < 0.7.9
 ruff
 tox
 

--- a/tests/unit_tests/clients/test_async_unleash_client.py
+++ b/tests/unit_tests/clients/test_async_unleash_client.py
@@ -246,3 +246,19 @@ def test_constructing_the_async_client_does_not_start_the_scheduler(tmpdir):
     client = build_async_client(tmpdir, url=URL, app_name=APP_NAME)
 
     assert not client._scheduler.scheduler.running
+
+
+def test_async_client_builds_a_transport_over_its_config_and_headers(tmpdir):
+    client = build_async_client(tmpdir, url=URL, app_name=APP_NAME)
+
+    assert client._transport._config is client._config
+    assert client._transport._headers is client._headers
+
+
+def test_constructing_the_async_client_opens_no_session(tmpdir):
+    # No event loop is running here, and none is needed: aiohttp resolves the
+    # loop when a ClientSession is built, so the transport has to defer that to
+    # the first request.
+    client = build_async_client(tmpdir, url=URL, app_name=APP_NAME)
+
+    assert client._transport._session is None

--- a/tests/unit_tests/test_async_transport.py
+++ b/tests/unit_tests/test_async_transport.py
@@ -1,0 +1,551 @@
+import json
+from typing import Callable
+
+import aiohttp
+import pytest
+import pytest_asyncio
+from pytest import mark, param
+
+from tests.utilities.fake_unleash_server import FakeUnleash
+from tests.utilities.mocks.mock_features import (
+    MOCK_FEATURE_RESPONSE,
+    MOCK_FEATURE_RESPONSE_PROJECT,
+)
+from tests.utilities.mocks.mock_metrics import MOCK_METRICS_REQUEST
+from tests.utilities.testing_constants import (
+    APP_NAME,
+    ASYNC_CUSTOM_OPTIONS,
+    CUSTOM_HEADERS,
+    ETAG_VALUE,
+    INSTANCE_ID,
+    PROJECT_NAME,
+    REQUEST_RETRIES,
+    REQUEST_TIMEOUT,
+)
+from UnleashClient.async_transport import AsyncTransport
+from UnleashClient.config import UnleashConfig
+from UnleashClient.constants import (
+    CLIENT_SPEC_VERSION,
+    FEATURES_URL,
+    METRICS_URL,
+    REGISTER_URL,
+)
+from UnleashClient.headers import HeaderFactory
+
+# testing_constants.URL mounts Unleash under /api, and the fake server does the
+# same, so the transport builds the URL shape it builds against a deployment.
+API_PREFIX = "/api"
+FEATURES_PATH = API_PREFIX + FEATURES_URL
+REGISTER_PATH = API_PREFIX + REGISTER_URL
+METRICS_PATH = API_PREFIX + METRICS_URL
+
+
+@pytest_asyncio.fixture
+async def server():
+    """A real Unleash server on an ephemeral port, stopped on teardown."""
+    fake = FakeUnleash()
+    await fake.start(API_PREFIX)
+    try:
+        yield fake
+    finally:
+        await fake.close()
+
+
+@pytest_asyncio.fixture
+async def build_transport(server: FakeUnleash):
+    """
+    Factory pointed at the fake server. Keyword arguments override the defaults
+    on the config.
+
+    Every transport it builds is closed on teardown: nothing calls aclose() in
+    production yet, and an unclosed ClientSession is reported by aiohttp on
+    garbage collection.
+    """
+    built = []
+
+    def _build_transport(**kwargs) -> AsyncTransport:
+        defaults = {
+            "instance_id": INSTANCE_ID,
+            "custom_headers": CUSTOM_HEADERS,
+            "custom_options": ASYNC_CUSTOM_OPTIONS,
+            "request_timeout": REQUEST_TIMEOUT,
+            "request_retries": REQUEST_RETRIES,
+        }
+        defaults.update(kwargs)
+        config = UnleashConfig(server.base_url, APP_NAME, **defaults)
+        transport = AsyncTransport(config, HeaderFactory(config))
+        built.append(transport)
+        return transport
+
+    try:
+        yield _build_transport
+    finally:
+        for transport in built:
+            await transport.aclose()
+
+
+@pytest_asyncio.fixture
+async def transport(build_transport: Callable[..., AsyncTransport]) -> AsyncTransport:
+    """The transport the tests that need no config override share."""
+    return build_transport()
+
+
+# fetch_features
+
+
+@mark.asyncio
+@mark.parametrize(
+    "response,status,call_count,expected",
+    (
+        param(
+            MOCK_FEATURE_RESPONSE,
+            200,
+            1,
+            lambda result: json.loads(result)["version"] == 1,
+            id="success",
+        ),
+        param(MOCK_FEATURE_RESPONSE, 202, 1, lambda result: not result, id="failure"),
+        param({}, 500, 4, lambda result: not result, id="failure"),
+    ),
+)
+async def test_fetch_features(
+    server, transport, response, status, call_count, expected
+):
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=status,
+        payload=response,
+        headers={"etag": ETAG_VALUE},
+        repeat=True,
+    )
+
+    result = await transport.fetch_features()
+
+    # 4 calls on a 500 is 1 + REQUEST_RETRIES, as the sync transport's
+    # mounted HTTPAdapter/Retry gives it.
+    assert len(server.calls("GET", FEATURES_PATH)) == call_count
+    assert expected(result.raw_state)
+
+
+@mark.asyncio
+async def test_fetch_features_sends_the_project_as_a_query_parameter(
+    server, build_transport
+):
+    transport = build_transport(project_name=PROJECT_NAME)
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=200,
+        payload=MOCK_FEATURE_RESPONSE_PROJECT,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    result = await transport.fetch_features()
+
+    calls = server.calls("GET", FEATURES_PATH)
+    assert len(calls) == 1
+    assert calls[0].query == {"project": PROJECT_NAME}
+    assert len(json.loads(result.raw_state)["features"]) == 1
+    assert result.etag == ETAG_VALUE
+
+
+@mark.asyncio
+async def test_fetch_features_drops_the_etag_on_failure(server, build_transport):
+    transport = build_transport(project_name=PROJECT_NAME)
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=500,
+        payload={},
+        headers={"etag": ETAG_VALUE},
+        repeat=True,
+    )
+
+    result = await transport.fetch_features()
+
+    assert len(server.calls("GET", FEATURES_PATH)) == 4
+    assert not result.etag
+    assert result.not_modified is False
+
+
+@mark.asyncio
+async def test_fetch_features_sends_if_none_match_when_an_etag_is_known(
+    server, build_transport
+):
+    transport = build_transport(project_name=PROJECT_NAME)
+    server.on("GET", FEATURES_PATH, status=304, headers={"etag": ETAG_VALUE})
+
+    result = await transport.fetch_features(ETAG_VALUE)
+
+    calls = server.calls("GET", FEATURES_PATH)
+    assert len(calls) == 1
+    assert calls[0].headers["If-None-Match"] == ETAG_VALUE
+    assert result.raw_state is None
+    assert result.etag == ETAG_VALUE
+    # 304 and a hard failure are both raw_state=None; only this tells them apart.
+    assert result.not_modified is True
+
+
+@mark.asyncio
+async def test_fetch_features_retries_and_recovers(server, build_transport):
+    transport = build_transport(project_name=PROJECT_NAME)
+    server.on("GET", FEATURES_PATH, status=500, payload={})
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=200,
+        payload=MOCK_FEATURE_RESPONSE_PROJECT,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    result = await transport.fetch_features(ETAG_VALUE)
+
+    assert len(server.calls("GET", FEATURES_PATH)) == 2
+    assert len(json.loads(result.raw_state)["features"]) == 1
+    assert result.etag == ETAG_VALUE
+
+
+@mark.asyncio
+async def test_fetch_features_retries_and_recovers_from_a_connection_error(
+    server, build_transport
+):
+    transport = build_transport(project_name=PROJECT_NAME)
+    server.on("GET", FEATURES_PATH, disconnect=True)
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=200,
+        payload=MOCK_FEATURE_RESPONSE_PROJECT,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    # urllib3's Retry covers connection failures as well as the status
+    # forcelist, so the hand-rolled loop has to do both.
+    result = await transport.fetch_features(ETAG_VALUE)
+
+    assert len(server.calls("GET", FEATURES_PATH)) == 2
+    assert len(json.loads(result.raw_state)["features"]) == 1
+
+
+@mark.asyncio
+async def test_fetch_features_carries_the_uppercase_identification_headers(
+    server, transport, mocker
+):
+    # The spelling is read off the request rather than off the wire: header
+    # names are case-insensitive, so a server cannot tell the uppercase copy
+    # from the lowercase pair HeaderFactory.polling() already carries.
+    spy = mocker.spy(aiohttp.ClientSession, "get")
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=200,
+        payload=MOCK_FEATURE_RESPONSE,
+        headers={"etag": ETAG_VALUE},
+    )
+
+    await transport.fetch_features()
+
+    sent = spy.call_args.kwargs["headers"]
+    assert [key for key in sent if key.lower() == "unleash-appname"] == [
+        "UNLEASH-APPNAME"
+    ]
+    assert [key for key in sent if key.lower() == "unleash-instanceid"] == [
+        "UNLEASH-INSTANCEID"
+    ]
+
+    received = server.calls("GET", FEATURES_PATH)[0].headers
+    assert received["unleash-appname"] == APP_NAME
+    assert received["unleash-instanceid"] == INSTANCE_ID
+
+
+@mark.asyncio
+async def test_fetch_features_sends_each_identification_header_once(
+    server, transport, mocker
+):
+    # Read off the request rather than off the wire: aiohttp folds repeated
+    # spellings of a header itself, so a server cannot tell a transport that
+    # merged them from one that did not.
+    spy = mocker.spy(aiohttp.ClientSession, "get")
+    server.on("GET", FEATURES_PATH, status=200, payload=MOCK_FEATURE_RESPONSE)
+
+    await transport.fetch_features()
+
+    # HeaderFactory.base() carries a lowercase pair and the features
+    # endpoint adds an uppercase one. requests folds the two into a single
+    # header; aiohttp would put both spellings on the wire unless the merge
+    # happens in a CIMultiDict first.
+    headers = spy.call_args.kwargs["headers"]
+    assert headers.getall("unleash-appname") == [APP_NAME]
+    assert headers.getall("unleash-instanceid") == [INSTANCE_ID]
+
+
+@mark.asyncio
+async def test_fetch_features_strips_a_trailing_slash_from_the_url(server, transport):
+    server.on(
+        "GET",
+        FEATURES_PATH,
+        status=200,
+        payload=MOCK_FEATURE_RESPONSE,
+        headers={"etag": ETAG_VALUE},
+    )
+    # The unleash_url setter writes config.url directly and never
+    # re-normalizes, so the trailing slash has to be stripped at request time.
+    transport._config.url = f"{server.base_url}/"
+
+    result = await transport.fetch_features()
+
+    assert len(server.calls("GET", FEATURES_PATH)) == 1
+    assert json.loads(result.raw_state)["version"] == 1
+    assert result.etag == ETAG_VALUE
+
+
+@mark.asyncio
+async def test_fetch_features_swallows_a_bad_custom_option(server, build_transport):
+    transport = build_transport(custom_options={"verify": False})
+    server.on("GET", FEATURES_PATH, status=200, payload=MOCK_FEATURE_RESPONSE)
+
+    # `verify` is a requests keyword; aiohttp rejects it while binding the
+    # call. It is a TypeError, not a ClientError, and fetch_features
+    # swallows everything.
+    result = await transport.fetch_features()
+
+    assert result == (None, "", False)
+    assert server.calls("GET", FEATURES_PATH) == []
+
+
+# register
+
+
+@mark.asyncio
+@mark.parametrize(
+    "reply,expected",
+    (
+        param({"status": 202, "payload": {}}, True, id="success"),
+        param({"status": 200, "payload": {}}, True, id="success-200"),
+        param({"status": 500, "payload": {}}, False, id="failure"),
+        param({"disconnect": True}, False, id="connection-error"),
+    ),
+)
+async def test_register(server, transport, reply, expected):
+    server.on("POST", REGISTER_PATH, **reply)
+
+    result = await transport.register({"appName": APP_NAME})
+
+    # No retry loop on this one, unlike fetch_features.
+    assert len(server.calls("POST", REGISTER_PATH)) == 1
+    assert result is expected
+
+
+@mark.asyncio
+async def test_register_sends_the_payload_it_is_given(server, transport):
+    server.on("POST", REGISTER_PATH, status=202, payload={})
+
+    await transport.register({"appName": APP_NAME, "strategies": []})
+
+    body = server.calls("POST", REGISTER_PATH)[0].body
+    assert json.loads(body) == {"appName": APP_NAME, "strategies": []}
+
+
+@mark.asyncio
+async def test_register_strips_a_trailing_slash_from_the_url(server, transport):
+    server.on("POST", REGISTER_PATH, status=202, payload={})
+    transport._config.url = f"{server.base_url}/"
+
+    result = await transport.register({})
+
+    assert len(server.calls("POST", REGISTER_PATH)) == 1
+    assert result is True
+
+
+@mark.asyncio
+@mark.parametrize(
+    "url", ("thisisnotavalidurl", "localhost:4242/api"), ids=("no-scheme", "bad-scheme")
+)
+async def test_register_reraises_an_unusable_url(server, transport, url):
+    transport._config.url = url
+
+    # initialize_client() fails loudly on a malformed URL because these are
+    # re-raised rather than reported as False.
+    with pytest.raises(aiohttp.ClientError):
+        await transport.register({})
+
+    # Raised before a socket is opened, so nothing reaches the server.
+    assert server.requests == []
+
+
+@mark.asyncio
+async def test_register_reraises_a_missing_scheme_as_a_value_error(transport):
+    transport._config.url = "thisisnotavalidurl"
+
+    # test_uc_with_invalid_url only sees the ValueError that requests'
+    # MissingSchema subclasses; aiohttp's InvalidURL subclasses it too, so the
+    # sync client's contract carries over.
+    with pytest.raises(ValueError):
+        await transport.register({})
+
+
+@mark.asyncio
+async def test_register_lets_a_bad_custom_option_escape(server, build_transport):
+    transport = build_transport(custom_options={"verify": False})
+    server.on("POST", REGISTER_PATH, status=202, payload={})
+
+    # A TypeError is not a ClientError, so unlike fetch_features this
+    # propagates and fails initialize_client().
+    with pytest.raises(TypeError):
+        await transport.register({})
+
+
+# send_metrics
+
+
+@mark.asyncio
+@mark.parametrize(
+    "reply,expected",
+    (
+        param({"status": 202, "payload": {}}, True, id="success"),
+        param({"status": 200, "payload": {}}, False, id="200-is-a-failure"),
+        param({"status": 500, "payload": {}}, False, id="failure"),
+        param({"disconnect": True}, False, id="connection-error"),
+    ),
+)
+async def test_send_metrics(server, transport, reply, expected):
+    server.on("POST", METRICS_PATH, **reply)
+
+    result = await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    calls = server.calls("POST", METRICS_PATH)
+    assert len(calls) == 1
+    assert result is expected
+
+    body = json.loads(calls[0].body)
+    assert body["connectionId"] == MOCK_METRICS_REQUEST.get("connectionId")
+
+
+@mark.asyncio
+async def test_send_metrics_strips_a_trailing_slash_from_the_url(server, transport):
+    server.on("POST", METRICS_PATH, status=202, payload={})
+    transport._config.url = f"{server.base_url}/"
+
+    result = await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    assert len(server.calls("POST", METRICS_PATH)) == 1
+    assert result is True
+
+
+@mark.asyncio
+async def test_send_metrics_lets_a_bad_custom_option_escape(server, build_transport):
+    transport = build_transport(custom_options={"verify": False})
+    server.on("POST", METRICS_PATH, status=202, payload={})
+
+    with pytest.raises(TypeError):
+        await transport.send_metrics({})
+
+
+# config read-through
+
+
+@mark.asyncio
+async def test_the_config_is_read_on_every_request(server, transport, mocker):
+    # Read off the request rather than off the wire: a timeout is aiohttp's own
+    # bookkeeping and never reaches the server.
+    spy = mocker.spy(aiohttp.ClientSession, "post")
+    server.on("POST", METRICS_PATH, status=202, payload={})
+
+    transport._config.request_timeout = 7
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    # unleash_request_timeout and friends are public setters, so an
+    # AsyncTransport built in __init__ has to pick up a change made after
+    # initialize_client().
+    timeout = spy.call_args.kwargs["timeout"]
+    # sock_connect/sock_read rather than total: requests' scalar timeout
+    # bounds each socket operation, not the whole request.
+    assert timeout == aiohttp.ClientTimeout(total=None, sock_connect=7, sock_read=7)
+
+
+@mark.asyncio
+async def test_every_endpoint_gets_its_headers_from_the_factory(
+    server, build_transport
+):
+    transport = build_transport(refresh_interval=1, metrics_interval=2)
+    server.on("GET", FEATURES_PATH, status=200, payload=MOCK_FEATURE_RESPONSE)
+    server.on("POST", REGISTER_PATH, status=202, payload={})
+    server.on("POST", METRICS_PATH, status=202, payload={})
+
+    await transport.fetch_features()
+    await transport.register({})
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    fetch = server.calls("GET", FEATURES_PATH)[0].headers
+    register = server.calls("POST", REGISTER_PATH)[0].headers
+    metrics = server.calls("POST", METRICS_PATH)[0].headers
+    # The custom header and the identification pair reach all three...
+    for headers in (fetch, register, metrics):
+        assert headers["name"] == CUSTOM_HEADERS["name"]
+        assert headers["unleash-appname"] == APP_NAME
+        assert headers["Unleash-Client-Spec"] == CLIENT_SPEC_VERSION
+    # ...and each endpoint gets the interval its own header set carries.
+    assert fetch["unleash-interval"] == "1000"
+    assert "unleash-interval" not in register
+    assert metrics["unleash-interval"] == "2000"
+
+
+@mark.asyncio
+async def test_headers_are_rebuilt_on_every_request(server, transport):
+    server.on("POST", METRICS_PATH, status=202, payload={}, repeat=True)
+
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+    # unleash_custom_headers is a public setter, so the factory has to be
+    # asked again rather than its answer captured.
+    transport._config.custom_headers = {"Authorization": "second"}
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    calls = server.calls("POST", METRICS_PATH)
+    assert "Authorization" not in calls[0].headers
+    assert calls[1].headers["Authorization"] == "second"
+
+
+# session lifecycle -- no sync counterpart
+
+
+@mark.asyncio
+async def test_the_session_is_reused_across_requests(server, transport):
+    server.on("POST", METRICS_PATH, status=202, payload={}, repeat=True)
+
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+    first = transport._session
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    assert first is not None
+    assert transport._session is first
+
+
+@mark.asyncio
+async def test_aclose_is_a_no_op_before_any_request(build_transport):
+    transport = build_transport()
+
+    await transport.aclose()
+    await transport.aclose()
+
+    assert transport._session is None
+
+
+@mark.asyncio
+async def test_aclose_closes_the_session_and_a_later_request_opens_a_new_one(
+    server, transport
+):
+    server.on("POST", METRICS_PATH, status=202, payload={}, repeat=True)
+
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+    first = transport._session
+    await transport.aclose()
+
+    assert first.closed
+    assert transport._session is None
+
+    # A closed session is not reused: aiohttp refuses to send on one.
+    await transport.send_metrics(MOCK_METRICS_REQUEST)
+
+    assert transport._session is not None
+    assert transport._session is not first

--- a/tests/utilities/fake_unleash_server.py
+++ b/tests/utilities/fake_unleash_server.py
@@ -1,0 +1,173 @@
+import logging
+from collections import deque
+from typing import Any, Deque, Dict, List, NamedTuple, Optional, Tuple
+
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from multidict import CIMultiDictProxy
+
+#: Answered for a request no reply was scripted for.
+UNEXPECTED_REQUEST_STATUS = 599
+
+_Route = Tuple[str, str]
+
+
+class RecordedRequest(NamedTuple):
+    """One request as the server parsed it off the wire."""
+
+    method: str
+    path: str
+    query: Dict[str, str]
+    headers: CIMultiDictProxy
+    body: str
+
+
+class _Reply(NamedTuple):
+    status: int
+    payload: Optional[Any]
+    headers: Dict[str, str]
+    disconnect: bool
+
+
+class FakeUnleash:
+    """
+    A programmable Unleash server that tests can make real requests against.
+
+    Replies are scripted per method and path with :meth:`on`, and every request
+    that arrives is recorded for :meth:`calls`. Assertions therefore run against
+    what the client put on the wire rather than against the arguments it handed
+    aiohttp, which is what makes this usable in place of a library that patches
+    ``ClientSession``.
+
+    A request that no reply was scripted for is recorded and answered
+    :data:`UNEXPECTED_REQUEST_STATUS`, so a mistargeted URL fails its test
+    instead of quietly matching something else.
+    """
+
+    def __init__(self) -> None:
+        self.base_url: str = ""
+        self.requests: List[RecordedRequest] = []
+        self._queued: Dict[_Route, Deque[_Reply]] = {}
+        self._repeated: Dict[_Route, _Reply] = {}
+        self._server: Optional[TestServer] = None
+        self._server_log_level: Optional[int] = None
+
+    def on(
+        self,
+        method: str,
+        path: str,
+        *,
+        status: int = 200,
+        payload: Optional[Any] = None,
+        headers: Optional[Dict[str, str]] = None,
+        repeat: bool = False,
+        disconnect: bool = False,
+    ) -> None:
+        """
+        Script one reply.
+
+        Queued replies are served in the order they were scripted, which is how
+        a test drives a retry through a failure and into a success.
+
+        :param method: HTTP method to match.
+        :param path: request path to match, including any API prefix.
+        :param status: status code to answer with.
+        :param payload: JSON body to answer with, or None for an empty body.
+        :param headers: response headers, such as an etag.
+        :param repeat: serve this reply for every matching request rather than
+                       once.
+        :param disconnect: close the connection without answering, which the
+                           client sees as a ``ClientConnectionError``.
+        """
+        reply = _Reply(status, payload, headers or {}, disconnect)
+        route = (method.upper(), path)
+
+        if repeat:
+            self._repeated[route] = reply
+        else:
+            self._queued.setdefault(route, deque()).append(reply)
+
+    def calls(self, method: str, path: str) -> List[RecordedRequest]:
+        """
+        Every request that reached this server for a method and path, in order.
+
+        :param method: HTTP method to match.
+        :param path: request path to match, excluding the query string.
+        """
+        method = method.upper()
+        return [
+            request
+            for request in self.requests
+            if request.method == method and request.path == path
+        ]
+
+    async def start(self, path_prefix: str = "") -> str:
+        """
+        Listen on an ephemeral port and return the base URL to configure a
+        client with.
+
+        :param path_prefix: mounted ahead of the Unleash endpoints, so a test
+                            exercises the same URL shape as a real deployment.
+        """
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", self._handle)
+
+        self._server = TestServer(app)
+        await self._server.start_server()
+
+        # A deliberate disconnect leaves the handler with nothing to answer on,
+        # which aiohttp reports as an unhandled server error. Unexpected
+        # requests are surfaced through UNEXPECTED_REQUEST_STATUS instead.
+        server_log = logging.getLogger("aiohttp.server")
+        self._server_log_level = server_log.level
+        server_log.setLevel(logging.CRITICAL)
+
+        self.base_url = str(self._server.make_url(path_prefix)).rstrip("/")
+        return self.base_url
+
+    async def close(self) -> None:
+        """Stop listening and restore the aiohttp server log level."""
+        if self._server_log_level is not None:
+            logging.getLogger("aiohttp.server").setLevel(self._server_log_level)
+            self._server_log_level = None
+
+        if self._server is not None:
+            await self._server.close()
+            self._server = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.requests.append(
+            RecordedRequest(
+                method=request.method,
+                path=request.path,
+                query=dict(request.query),
+                headers=request.headers.copy(),
+                body=await request.text(),
+            )
+        )
+
+        reply = self._next_reply((request.method, request.path))
+
+        if reply is None:
+            return web.Response(
+                status=UNEXPECTED_REQUEST_STATUS, text=f"unscripted {request.rel_url}"
+            )
+
+        if reply.disconnect:
+            request.transport.abort()
+            raise ConnectionResetError("disconnected by FakeUnleash")
+
+        if reply.payload is None:
+            return web.Response(status=reply.status, headers=reply.headers)
+
+        return web.json_response(
+            reply.payload, status=reply.status, headers=reply.headers
+        )
+
+    def _next_reply(self, route: _Route) -> Optional[_Reply]:
+        queued = self._queued.get(route)
+
+        if queued:
+            return queued.popleft()
+
+        return self._repeated.get(route)

--- a/tests/utilities/testing_constants.py
+++ b/tests/utilities/testing_constants.py
@@ -13,6 +13,9 @@ DISABLE_METRICS = True
 DISABLE_REGISTRATION = True
 CUSTOM_HEADERS = {"name": "My random header."}
 CUSTOM_OPTIONS = {"verify": False}
+# The aiohttp spelling of the same intent. `verify` is a requests keyword and
+# raises TypeError against AsyncTransport -- see the async transport docstring.
+ASYNC_CUSTOM_OPTIONS = {"ssl": False}
 REQUEST_TIMEOUT = 30
 REQUEST_RETRIES = 3
 


### PR DESCRIPTION
This should be part of Stack #411, but I haven't managed to split that first PR. This is so the `AsyncTransport` and the `Evaluator` aren't part of the same huge PR.

- **chore: install aiohttp as an optional-dependency**
- **feat: Implement new `AsyncTransport`**
- **feat: wire AsyncUnleashClient with an AsyncTransport**
